### PR TITLE
IOS - Allow local files from static server.

### DIFF
--- a/ios/RNTrackPlayer/Models/MediaURL.swift
+++ b/ios/RNTrackPlayer/Models/MediaURL.swift
@@ -12,11 +12,11 @@ struct MediaURL {
     let value: URL
     let isLocal: Bool
     private let originalObject: Any
-    
+
     init?(object: Any?) {
         guard let object = object else { return nil }
         originalObject = object
-        
+
         if let localObject = object as? [String: Any] {
             isLocal = true
             let uri = localObject["uri"] as! String
@@ -24,7 +24,7 @@ struct MediaURL {
             value = URL(string: encodedURI)!
         } else {
             let url = object as! String
-            isLocal = url.lowercased().hasPrefix("file://")
+            isLocal = url.lowercased().hasPrefix("file://") || url.lowercased().hasPrefix("http://localhosts")
             value = URL(string: url)!
         }
     }

--- a/ios/RNTrackPlayer/Models/MediaURL.swift
+++ b/ios/RNTrackPlayer/Models/MediaURL.swift
@@ -24,7 +24,7 @@ struct MediaURL {
             value = URL(string: encodedURI)!
         } else {
             let url = object as! String
-            isLocal = url.lowercased().hasPrefix("file://") || url.lowercased().hasPrefix("http://localhosts")
+            isLocal = url.lowercased().hasPrefix("file://") || url.lowercased().hasPrefix("http://localhost")
             value = URL(string: url)!
         }
     }


### PR DESCRIPTION
Local files might be located on a static server (eg using https://www.npmjs.com/package/react-native-static-server). In these cases the file will not be prefixed with file:// but are still playable with a network connection.