### PR TITLE
Check for playWhenReady

### DIFF
--- a/ios/RNTrackPlayer/Vendor/AudioPlayer/QueuedAudioPlayer.swift
+++ b/ios/RNTrackPlayer/Vendor/AudioPlayer/QueuedAudioPlayer.swift
@@ -90,7 +90,9 @@ public class QueuedAudioPlayer: AudioPlayer {
     public func add(items: [AudioItem], playWhenReady: Bool = true) throws {
         if currentItem == nil {
             queueManager.addItems(items)
-            try self.load(item: currentItem!, playWhenReady: playWhenReady)
+            if playWhenReady == true { 
+             try self.load(item: currentItem!, playWhenReady: playWhenReady)
+            }
         }
         else {
             queueManager.addItems(items)

--- a/ios/RNTrackPlayer/Vendor/AudioPlayer/QueuedAudioPlayer.swift
+++ b/ios/RNTrackPlayer/Vendor/AudioPlayer/QueuedAudioPlayer.swift
@@ -71,7 +71,9 @@ public class QueuedAudioPlayer: AudioPlayer {
     public func add(item: AudioItem, playWhenReady: Bool = true) throws {
         if currentItem == nil {
             queueManager.addItem(item)
-            try self.load(item: item, playWhenReady: playWhenReady)
+            if playWhenReady == true { 
+             try self.load(item: item, playWhenReady: playWhenReady)
+            }
         }
         else {
             queueManager.addItem(item)


### PR DESCRIPTION
We should also check for <code>playWhenReady = true</code> within the add function, otherwise the player will always load the first item. This could be a problem when you have a slow internet connection. Fixes #452 