### PR TITLE
fixed NullPointerException when empty url is given

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -113,7 +113,7 @@ public class Track {
         builder.putString(METADATA_KEY_ALBUM, album);
         builder.putString(METADATA_KEY_DATE, date);
         builder.putString(METADATA_KEY_GENRE, genre);
-        builder.putString(METADATA_KEY_MEDIA_URI, uri.toString());
+        builder.putString(METADATA_KEY_MEDIA_URI, (uri != null)?uri.toString():"");
         builder.putString(METADATA_KEY_MEDIA_ID, id);
 
         builder.putLong(METADATA_KEY_DURATION, duration);


### PR DESCRIPTION
Whole app crashes on android when the javascript's track.url is ""(empty string), null or undefined. A simple if statement can fix that.