### PR TITLE
[iOS] add optional urlDecoding

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ declare namespace RNTrackPlayer {
     maxBuffer?: number;
     playBuffer?: number;
     maxCacheSize?: number;
+    iosUrlDecoding?: boolean;
     iosCategory?: 'playback' | 'playAndRecord' | 'multiRoute' | 'ambient' | 'soloAmbient' | 'record';
     iosCategoryMode?: 'default' | 'gameChat' | 'measurement' | 'moviePlayback' | 'spokenAudio' | 'videoChat' | 'videoRecording' | 'voiceChat' | 'voicePrompt';
     iosCategoryOptions?: Array<'mixWithOthers' | 'duckOthers' | 'interruptSpokenAudioAndMixWithOthers' | 'allowBluetooth' | 'allowBluetoothA2DP' | 'allowAirPlay' | 'defaultToSpeaker'>;

--- a/ios/RNTrackPlayer/Models/MediaURL.swift
+++ b/ios/RNTrackPlayer/Models/MediaURL.swift
@@ -13,7 +13,7 @@ struct MediaURL {
     let isLocal: Bool
     private let originalObject: Any
     
-    init?(object: Any?) {
+    init?(object: Any?, urlDecode: Bool) {
         guard let object = object else { return nil }
         originalObject = object
         
@@ -26,7 +26,7 @@ struct MediaURL {
             let url = object as! String
             let urlencoded = url.removingPercentEncoding
             isLocal = url.lowercased().hasPrefix("file://")
-            if let encoded = urlencoded!.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed
+            if urlDecode, let encoded = urlencoded!.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlFragmentAllowed
                 .union(.urlHostAllowed)
                 .union(.urlPasswordAllowed)
                 .union(.urlQueryAllowed)

--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -28,11 +28,11 @@ class Track: NSObject, AudioItem, TimePitching {
     
     private var originalObject: [String: Any]
     
-    init?(dictionary: [String: Any]) {
+    init?(dictionary: [String: Any], urlDecode: Bool = true) {
         guard let id = dictionary["id"] as? String,
             let title = dictionary["title"] as? String,
             let artist = dictionary["artist"] as? String,
-            let url = MediaURL(object: dictionary["url"])
+            let url = MediaURL(object: dictionary["url"], urlDecode)
             else { return nil }
         
         self.id = id
@@ -46,7 +46,7 @@ class Track: NSObject, AudioItem, TimePitching {
         self.desc = dictionary["description"] as? String
         self.pitchAlgorithm = dictionary["pitchAlgorithm"] as? String
         self.duration = dictionary["duration"] as? Double
-        self.artworkURL = MediaURL(object: dictionary["artwork"])
+        self.artworkURL = MediaURL(object: dictionary["artwork"], urlDecode)
         
         self.originalObject = dictionary
     }

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -20,6 +20,8 @@ public class RNTrackPlayer: RCTEventEmitter {
         return player
     }()
     
+    private var urlDecode: Bool = true
+    
     // MARK: - Lifecycle Methods
     
     deinit {
@@ -99,6 +101,8 @@ public class RNTrackPlayer: RCTEventEmitter {
         var sessionCategory: AVAudioSession.Category = .playback
         var sessionCategoryOptions: AVAudioSession.CategoryOptions = []
         var sessionCategoryMode: AVAudioSession.Mode = .default
+
+        self.urlDecode = config["iosUrlDecoding"] as? Bool ?? true
 
         if
             let sessionCategoryStr = config["iosCategory"] as? String,
@@ -237,7 +241,7 @@ public class RNTrackPlayer: RCTEventEmitter {
 
         var tracks = [Track]()
         for trackDict in trackDicts {
-            guard let track = Track(dictionary: trackDict) else {
+            guard let track = Track(dictionary: trackDict, urlDecode: self.urlDecode) else {
                 reject("invalid_track_object", "Track is missing a required key", nil)
                 return
             }


### PR DESCRIPTION
stems from this issue: #543 

- allow setting a `iosUrlDecoding` boolean in the track player config
- store it in the TrackPlayer class
- disable decoding of URLs if it is set to false
- enable decoding by default

I'm not a swift developer, tell me if there is anything that I should change. 

I feel that having an option will satisfy everyone

@Guichaguri  @dcvz 