### PR TITLE
Support For Providing A StartPosition With Track

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -8,6 +8,7 @@ import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaSessionCompat.QueueItem;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
+import com.google.android.exoplayer2.source.ClippingMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
@@ -27,11 +28,15 @@ import java.util.List;
 import java.util.Map;
 
 import static android.support.v4.media.MediaMetadataCompat.*;
+import static com.google.android.exoplayer2.C.TIME_END_OF_SOURCE;
 
 /**
  * @author Guichaguri
  */
 public class Track {
+
+    // Multiplier to convert seconds to microseconds.
+    private static final long SEC_TO_US = 1000000;
 
     public static List<Track> createTracks(Context context, List objects, int ratingType) {
         List<Track> tracks = new ArrayList<>();
@@ -64,6 +69,7 @@ public class Track {
     public String date;
     public String genre;
     public long duration;
+    public long startPositionSec;
     public Bundle originalItem;
 
     public RatingCompat rating;
@@ -84,6 +90,7 @@ public class Track {
         }
 
         String trackType = bundle.getString("type", "default");
+        startPositionSec = Utils.getInt(bundle,"startPositionSec", 0);
 
         for(TrackType t : TrackType.values()) {
             if(t.name.equalsIgnoreCase(trackType)) {
@@ -209,20 +216,30 @@ public class Track {
 
         }
 
+        MediaSource mediaSource;
         switch(type) {
             case DASH:
-                return new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(ds), ds)
+                mediaSource = new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(ds), ds)
                         .createMediaSource(uri);
             case HLS:
-                return new HlsMediaSource.Factory(ds)
+                mediaSource = new HlsMediaSource.Factory(ds)
                         .createMediaSource(uri);
             case SMOOTH_STREAMING:
-                return new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(ds), ds)
+                mediaSource = new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(ds), ds)
                         .createMediaSource(uri);
             default:
-                return new ProgressiveMediaSource.Factory(ds, new DefaultExtractorsFactory()
+                mediaSource = new ProgressiveMediaSource.Factory(ds, new DefaultExtractorsFactory()
                         .setConstantBitrateSeekingEnabled(true))
                         .createMediaSource(uri);
+        }
+
+        if (startPositionSec > 0) {
+            return new ClippingMediaSource(
+                    mediaSource,
+                    startPositionSec * SEC_TO_US,
+                    TIME_END_OF_SOURCE);
+        } else {
+            return mediaSource;
         }
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/models/Track.java
@@ -7,8 +7,8 @@ import android.support.v4.media.MediaDescriptionCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.RatingCompat;
 import android.support.v4.media.session.MediaSessionCompat.QueueItem;
+
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
-import com.google.android.exoplayer2.source.ClippingMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 import static android.support.v4.media.MediaMetadataCompat.*;
-import static com.google.android.exoplayer2.C.TIME_END_OF_SOURCE;
 
 /**
  * @author Guichaguri
@@ -69,7 +68,7 @@ public class Track {
     public String date;
     public String genre;
     public long duration;
-    public long startPositionSec;
+    public long initialTime;
     public Bundle originalItem;
 
     public RatingCompat rating;
@@ -90,7 +89,7 @@ public class Track {
         }
 
         String trackType = bundle.getString("type", "default");
-        startPositionSec = Utils.getInt(bundle,"startPositionSec", 0);
+        initialTime = Utils.getInt(bundle,"initialTime", 0);
 
         for(TrackType t : TrackType.values()) {
             if(t.name.equalsIgnoreCase(trackType)) {
@@ -216,30 +215,20 @@ public class Track {
 
         }
 
-        MediaSource mediaSource;
         switch(type) {
             case DASH:
-                mediaSource = new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(ds), ds)
+                return new DashMediaSource.Factory(new DefaultDashChunkSource.Factory(ds), ds)
                         .createMediaSource(uri);
             case HLS:
-                mediaSource = new HlsMediaSource.Factory(ds)
+                return new HlsMediaSource.Factory(ds)
                         .createMediaSource(uri);
             case SMOOTH_STREAMING:
-                mediaSource = new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(ds), ds)
+                return new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(ds), ds)
                         .createMediaSource(uri);
             default:
-                mediaSource = new ProgressiveMediaSource.Factory(ds, new DefaultExtractorsFactory()
+                return new ProgressiveMediaSource.Factory(ds, new DefaultExtractorsFactory()
                         .setConstantBitrateSeekingEnabled(true))
                         .createMediaSource(uri);
-        }
-
-        if (startPositionSec > 0) {
-            return new ClippingMediaSource(
-                    mediaSource,
-                    startPositionSec * SEC_TO_US,
-                    TIME_END_OF_SOURCE);
-        } else {
-            return mediaSource;
         }
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -255,6 +255,10 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
             }
 
             manager.onTrackUpdate(previous, lastKnownPosition, next);
+
+            if (next.initialTime != 0) {
+                player.seekTo(next.initialTime * 1000);
+            }
         }
 
         lastKnownWindow = player.getCurrentWindowIndex();

--- a/example/react/components/Player.js
+++ b/example/react/components/Player.js
@@ -113,7 +113,7 @@ const styles = StyleSheet.create({
     backgroundColor: "grey"
   },
   progress: {
-    height: 1,
+    height: 10,
     width: "90%",
     marginTop: 10,
     flexDirection: "row"

--- a/example/react/data/playlist.json
+++ b/example/react/data/playlist.json
@@ -28,11 +28,21 @@
     "artwork": "https://picsum.photos/200"
   },
   {
-    "id": "9999",
+    "id": "5555",
+    "url": "https://drive.google.com/uc?export=download&id=1Q_6nZB1Rc39Ums3JPVeXVuAHSoLDVfPc",
+    "title": "Airplane Landing Airport Sound",
+    "artist": "Daniel Simion",
+    "artwork": "https://picsum.photos/200",
+    "duration": 13,
+    "initialTime": 9
+  },
+  {
+    "id": "6666",
     "url": "https://drive.google.com/uc?export=download&id=1x4SH0SJqKXjJHlyBS51lu2ENZKVKOErc",
     "title": "0-9 Male Vocalized Sound",
     "artist": "Mike Koenig",
     "artwork": "https://picsum.photos/200",
-    "startPositionSec": 5
+    "duration": 12,
+    "initialTime": 5
   }
 ]

--- a/example/react/data/playlist.json
+++ b/example/react/data/playlist.json
@@ -26,5 +26,13 @@
     "title": "Rhythm City (Demo)",
     "artist": "David Chavez",
     "artwork": "https://picsum.photos/200"
+  },
+  {
+    "id": "9999",
+    "url": "https://drive.google.com/uc?export=download&id=1x4SH0SJqKXjJHlyBS51lu2ENZKVKOErc",
+    "title": "0-9 Male Vocalized Sound",
+    "artist": "Mike Koenig",
+    "artwork": "https://picsum.photos/200",
+    "startPositionSec": 5
   }
 ]

--- a/example/react/screens/PlaylistScreen.js
+++ b/example/react/screens/PlaylistScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import TrackPlayer, { usePlaybackState } from "react-native-track-player";
+import TrackPlayer, { usePlaybackState, useTrackPlayerProgress } from "react-native-track-player";
 
 import Player from "../components/Player";
 import playlistData from "../data/playlist.json";
@@ -8,6 +8,7 @@ import localTrack from "../resources/pure.m4a";
 
 export default function LandingScreen() {
   const playbackState = usePlaybackState();
+  const trackPlayerProcess = useTrackPlayerProgress();
 
   useEffect(() => {
     TrackPlayer.setupPlayer();
@@ -62,7 +63,12 @@ export default function LandingScreen() {
         onPrevious={skipToPrevious}
         onTogglePlayback={togglePlayback}
       />
-      <Text style={styles.state}>{getStateName(playbackState)}</Text>
+      <View style={styles.state}>
+        <Text>{getStateName(playbackState)}</Text>
+        <Text>Current: {trackPlayerProcess.position | 0} sec</Text>
+        <Text>Buffered: {trackPlayerProcess.bufferedPosition | 0} sec</Text>
+        <Text>Duration: {trackPlayerProcess.duration | 0} sec</Text>
+      </View>
     </View>
   );
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare namespace RNTrackPlayer {
     contentType?: string;
     pitchAlgorithm?: PitchAlgorithm;
     [key: string]: any;
-    startPositionSec: number;
+    initialTime: number;
   }
 
   export interface PlayerOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ declare namespace RNTrackPlayer {
     contentType?: string;
     pitchAlgorithm?: PitchAlgorithm;
     [key: string]: any;
+    startPositionSec: number;
   }
 
   export interface PlayerOptions {

--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -10,7 +10,7 @@ import Foundation
 import MediaPlayer
 import AVFoundation
 
-class Track: NSObject, AudioItem, TimePitching, Authorizing {
+class Track: NSObject, AudioItem, InitialTiming, TimePitching, Authorizing {
     let id: String
     let url: MediaURL
     
@@ -23,6 +23,7 @@ class Track: NSObject, AudioItem, TimePitching, Authorizing {
     var duration: Double?
     var skipped: Bool = false
     var artworkURL: MediaURL?
+    var startPositionSec: TimeInterval = 0.0
     let headers: [String: Any]?
     let pitchAlgorithm: String?
     
@@ -50,6 +51,10 @@ class Track: NSObject, AudioItem, TimePitching, Authorizing {
         self.duration = dictionary["duration"] as? Double
         self.headers = dictionary["headers"] as? [String: Any]
         self.artworkURL = MediaURL(object: dictionary["artwork"])
+        let startPositionSec = dictionary["startPositionSec"] as? Double
+        if let x = startPositionSec {
+            self.startPositionSec = x
+        }
         self.pitchAlgorithm = dictionary["pitchAlgorithm"] as? String
         
         self.originalObject = dictionary
@@ -137,4 +142,8 @@ class Track: NSObject, AudioItem, TimePitching, Authorizing {
         return headers ?? [:]
     }
     
+    // MARK: - InitialTiming Protocol
+    func getInitialTime() -> TimeInterval {
+        return startPositionSec
+    }
 }

--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -23,7 +23,7 @@ class Track: NSObject, AudioItem, InitialTiming, TimePitching, Authorizing {
     var duration: Double?
     var skipped: Bool = false
     var artworkURL: MediaURL?
-    var startPositionSec: TimeInterval = 0.0
+    var initialTime: TimeInterval = 0.0
     let headers: [String: Any]?
     let pitchAlgorithm: String?
     
@@ -51,9 +51,9 @@ class Track: NSObject, AudioItem, InitialTiming, TimePitching, Authorizing {
         self.duration = dictionary["duration"] as? Double
         self.headers = dictionary["headers"] as? [String: Any]
         self.artworkURL = MediaURL(object: dictionary["artwork"])
-        let startPositionSec = dictionary["startPositionSec"] as? Double
-        if let x = startPositionSec {
-            self.startPositionSec = x
+        let initialTime = dictionary["initialTime"] as? Double
+        if let x = initialTime {
+            self.initialTime = x
         }
         self.pitchAlgorithm = dictionary["pitchAlgorithm"] as? String
         
@@ -144,6 +144,6 @@ class Track: NSObject, AudioItem, InitialTiming, TimePitching, Authorizing {
     
     // MARK: - InitialTiming Protocol
     func getInitialTime() -> TimeInterval {
-        return startPositionSec
+        return initialTime
     }
 }


### PR DESCRIPTION
Summary:
This adds support for providing a startPosition with a track. If a startPosition
is provided, the track will start playing from the specified position.
The position is in seconds.

I chose to name it startPosition because we may want to add support for providing
an endPosition as well in order to only play a sub-clip of a track. It’s not part of this
PR as it requires additional changes to SwiftAudio on the iOS side. ExoPlayer on the
Android side already supports this.

Test Plan:
- verified on both iOS and Android with the example app
- used a new sound file that counts in order to easily verify that startPosition works as expected