### PR TITLE
Handle playback stalled event

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -79,6 +79,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             "playback-state",
             "playback-error",
             "playback-track-changed",
+            "playback-stalled",
             
             "remote-stop",
             "remote-pause",
@@ -197,6 +198,10 @@ public class RNTrackPlayer: RCTEventEmitter {
                     "nextTrack": (self.player.nextItems.first as? Track)?.id,
                     ])
             }
+        }
+
+        player.event.playbackStalled.addListener(self) { [weak self] currentItem in
+            self?.sendEvent(withName: "playback-stalled", body: ["track": (currentItem as? Track)?.id])
         }
         
         player.remoteCommandController.handleChangePlaybackPositionCommand = { [weak self] event in


### PR DESCRIPTION
When losing internet connection and running out of cache while playing a file-based stream on iOS the playback cannot be resumed when the connection is back. This PR handles the playbackStalled event which was added to SwiftAudio in this PR: https://github.com/dcvz/SwiftAudio/pull/7