### PR TITLE
[iOS] playback-metadata-received support

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -79,7 +79,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             "playback-state",
             "playback-error",
             "playback-track-changed",
-            
+            "playback-metadata-received",
             "remote-stop",
             "remote-pause",
             "remote-play",

--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -81,7 +81,6 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
     }
 
     override func AVWrapper(didReceiveMetadata metadata: [AVMetadataItem]) {
-      print(metadata);
         func getMetadataItem(forIdentifier:AVMetadataIdentifier) -> String? {
             let data: String = AVMetadataItem.metadataItems(from: metadata, filteredByIdentifier: forIdentifier).first?.stringValue ?? ""
             return data.isEmpty ? nil : data
@@ -114,7 +113,7 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
         data["title"] = getMetadataItem(forIdentifier: .commonIdentifierTitle)
         data["artist"] = getMetadataItem(forIdentifier: .commonIdentifierArtist)
         data["album"] = getMetadataItem(forIdentifier: .commonIdentifierAlbumName)
-        data["date"] = getMetadataItem(forIdentifier: .commonIdentifierCreationDate);
+        data["date"] = getMetadataItem(forIdentifier: .commonIdentifierCreationDate)
 
         if (source == "icy-headers") {
             data["title"] = getMetadataItem(forIdentifier: .icyMetadataStreamTitle)

--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -91,7 +91,7 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
             case AVMetadataKeySpace.id3:
                 return "id3"
             case AVMetadataKeySpace.icy:
-                return "icy-headers"
+                return "icy"
             case AVMetadataKeySpace.quickTimeMetadata:
                 return "quicktime"
             case AVMetadataKeySpace.common:
@@ -106,8 +106,7 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
         var date = getMetadataItem(forIdentifier: .commonIdentifierCreationDate)
         var url = "";
         var genre = "";
-        if (source == "icy-headers") {
-            title = getMetadataItem(forIdentifier: .icyMetadataStreamTitle)
+        if (source == "icy") {
             url = getMetadataItem(forIdentifier: .icyMetadataStreamURL)
         } else if (source == "id3") {
             if (date.isEmpty) {
@@ -123,17 +122,16 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
             }
         } else if (source == "quicktime") {
             genre = getMetadataItem(forIdentifier: .quickTimeMetadataGenre)
-        } else if (source == "unknown") {
-            // Detect ICY metadata by:
-            // - having "unknown" source
-            // - having title metadata
-            // - but no artist metadata
-            if (!title.isEmpty && artist.isEmpty) {
-                if let index = title.range(of: " - ")?.lowerBound {
-                    artist = String(title.prefix(upTo: index));
-                    title = String(title.suffix(from: title.index(index, offsetBy: 3)));
-                }
-          }
+        }
+
+        // Detect ICY metadata and split title into artist & title:
+        // - source should be either "unknown" (pre iOS 14) or "icy" (iOS 14 and above)
+        // - we have a title, but no artist
+        if ((source == "unknown" || source == "icy") && !title.isEmpty && artist.isEmpty) {
+            if let index = title.range(of: " - ")?.lowerBound {
+                artist = String(title.prefix(upTo: index));
+                title = String(title.suffix(from: title.index(index, offsetBy: 3)));
+            }
         }
         var data : [String : String?] = [
             "title": title.isEmpty ? nil : title,

--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -81,22 +81,12 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
     }
 
     override func AVWrapper(didReceiveMetadata metadata: [AVMetadataItem]) {
-        func getMetadataItem(forIdentifier:AVMetadataIdentifier) -> String? {
-            let data: String = AVMetadataItem.metadataItems(from: metadata, filteredByIdentifier: forIdentifier).first?.stringValue ?? ""
-            return data.isEmpty ? nil : data
+        func getMetadataItem(forIdentifier:AVMetadataIdentifier) -> String {
+            return AVMetadataItem.metadataItems(from: metadata, filteredByIdentifier: forIdentifier).first?.stringValue ?? ""
         }
 
         super.AVWrapper(didReceiveMetadata: metadata)
-        var data : Dictionary<String, Optional<String>> = [
-            "source": nil,
-            "title": nil,
-            "url": nil,
-            "artist": nil,
-            "album": nil,
-            "date": nil,
-            "genre": nil,
-        ]
-        var source: String? {
+        var source: String {
             switch metadata.first?.keySpace {
             case AVMetadataKeySpace.id3:
                 return "id3"
@@ -110,30 +100,49 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
             }
         }
 
-        data["title"] = getMetadataItem(forIdentifier: .commonIdentifierTitle)
-        data["artist"] = getMetadataItem(forIdentifier: .commonIdentifierArtist)
-        data["album"] = getMetadataItem(forIdentifier: .commonIdentifierAlbumName)
-        data["date"] = getMetadataItem(forIdentifier: .commonIdentifierCreationDate)
-
+        let album = getMetadataItem(forIdentifier: .commonIdentifierAlbumName)
+        var artist = getMetadataItem(forIdentifier: .commonIdentifierArtist)
+        var title = getMetadataItem(forIdentifier: .commonIdentifierTitle)
+        var date = getMetadataItem(forIdentifier: .commonIdentifierCreationDate)
+        var url = "";
+        var genre = "";
         if (source == "icy-headers") {
-            data["title"] = getMetadataItem(forIdentifier: .icyMetadataStreamTitle)
-            data["url"] = getMetadataItem(forIdentifier: .icyMetadataStreamURL)
+            title = getMetadataItem(forIdentifier: .icyMetadataStreamTitle)
+            url = getMetadataItem(forIdentifier: .icyMetadataStreamURL)
         } else if (source == "id3") {
-            if (data["date"] == nil) {
-              data["date"] = getMetadataItem(forIdentifier: .id3MetadataDate)
+            if (date.isEmpty) {
+              date = getMetadataItem(forIdentifier: .id3MetadataDate)
             }
-            data["genre"] = getMetadataItem(forIdentifier: .id3MetadataContentType)
-            data["url"] = getMetadataItem(forIdentifier: .id3MetadataOfficialAudioSourceWebpage)
-            if (data["url"] == nil) {
-              data["url"] = getMetadataItem(forIdentifier: .id3MetadataOfficialAudioFileWebpage)
+            genre = getMetadataItem(forIdentifier: .id3MetadataContentType)
+            url = getMetadataItem(forIdentifier: .id3MetadataOfficialAudioSourceWebpage)
+            if (url.isEmpty) {
+              url = getMetadataItem(forIdentifier: .id3MetadataOfficialAudioFileWebpage)
             }
-            if (data["url"] == nil) {
-              data["url"] = getMetadataItem(forIdentifier: .id3MetadataOfficialArtistWebpage)
+            if (url.isEmpty) {
+              url = getMetadataItem(forIdentifier: .id3MetadataOfficialArtistWebpage)
             }
         } else if (source == "quicktime") {
-            data["genre"] = getMetadataItem(forIdentifier: .quickTimeMetadataGenre)
+            genre = getMetadataItem(forIdentifier: .quickTimeMetadataGenre)
+        } else if (source == "unknown") {
+            // Detect ICY metadata by:
+            // - having "unknown" source
+            // - having title metadata
+            // - but no artist metadata
+            if (!title.isEmpty && artist.isEmpty) {
+                if let index = title.range(of: " - ")?.lowerBound {
+                    artist = String(title.prefix(upTo: index));
+                    title = String(title.suffix(from: title.index(index, offsetBy: 3)));
+                }
+          }
         }
-
+        var data : [String : String?] = [
+            "title": title.isEmpty ? nil : title,
+            "url": url.isEmpty ? nil : url,
+            "artist": artist.isEmpty ? nil : artist,
+            "album": album.isEmpty ? nil : album,
+            "date": date.isEmpty ? nil : date,
+            "genre": genre.isEmpty ? nil : genre
+        ]
         if (data.values.contains { $0 != nil }) {
             data["source"] = source
             self.reactEventEmitter.sendEvent(withName: "playback-metadata-received", body: data)

--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -105,8 +105,8 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
             case AVMetadataKeySpace.quickTimeMetadata:
                 return "quicktime"
             case AVMetadataKeySpace.common:
-                return "common"
-            default: return "other"
+                return "unknown"
+            default: return "unknown"
             }
         }
 

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -207,6 +207,9 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
                             self.playerObserver.startObserving()
                             self.playerItemNotificationObserver.startObserving(item: currentItem)
                             self.playerItemObserver.startObserving(item: currentItem)
+                            for format in pendingAsset.availableMetadataFormats {
+                                self.delegate?.AVWrapper(didReceiveMetadata: pendingAsset.metadata(forFormat: format))
+                            }
                         }
                         break
                         
@@ -339,5 +342,8 @@ extension AVPlayerWrapper: AVPlayerItemObserverDelegate {
     func item(didUpdateDuration duration: Double) {
         self.delegate?.AVWrapper(didUpdateDuration: duration)
     }
-    
+
+    func item(didReceiveMetadata metadata: [AVMetadataItem]) {
+        self.delegate?.AVWrapper(didReceiveMetadata: metadata)
+    }
 }

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperDelegate.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapperDelegate.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-
+import MediaPlayer
 
 protocol AVPlayerWrapperDelegate: class {
     
@@ -15,6 +15,7 @@ protocol AVPlayerWrapperDelegate: class {
     func AVWrapper(failedWithError error: Error?)
     func AVWrapper(seekTo seconds: Int, didFinish: Bool)
     func AVWrapper(didUpdateDuration duration: Double)
+    func AVWrapper(didReceiveMetadata metadata: [AVMetadataItem])
     func AVWrapperItemDidPlayToEndTime()
     func AVWrapperDidRecreateAVPlayer()
     

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AudioPlayer.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/AudioPlayer.swift
@@ -338,7 +338,11 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
     func AVWrapper(didUpdateDuration duration: Double) {
         self.event.updateDuration.emit(data: duration)
     }
-    
+
+    func AVWrapper(didReceiveMetadata metadata: [AVMetadataItem]) {
+        self.event.receiveMetadata.emit(data: metadata)
+    }
+
     func AVWrapperItemDidPlayToEndTime() {
         self.event.playbackEnd.emit(data: .playedUntilEnd)
     }

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/Event.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/Event.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import MediaPlayer
 
 extension AudioPlayer {
     
@@ -15,6 +16,7 @@ extension AudioPlayer {
     public typealias FailEventData = (Error?)
     public typealias SeekEventData = (seconds: Int, didFinish: Bool)
     public typealias UpdateDurationEventData = (Double)
+    public typealias MetadataEventData = ([AVMetadataItem])
     public typealias DidRecreateAVPlayerEventData = ()
     
     public struct EventHolder {
@@ -55,7 +57,13 @@ extension AudioPlayer {
          - Important: Remember to dispatch to the main queue if any UI is updated in the event handler.
          */
         public let updateDuration: AudioPlayer.Event<UpdateDurationEventData> = AudioPlayer.Event()
-        
+
+        /**
+         Emitted when the player receives metadata.
+          - Important: Remember to dispatch to the main queue if any UI is updated in the event handler.
+         */
+        public let receiveMetadata: AudioPlayer.Event<MetadataEventData> = AudioPlayer.Event()
+
         /**
          Emitted when the underlying AVPlayer instance is recreated. Recreation happens if the current player fails.
          - Important: Remember to dispatch to the main queue if any UI is updated in the event handler.


### PR DESCRIPTION
This pr extends support for the `playback-metadata-received` event to iOS. Note that the `source` property of this event is currently not yet aligned with that of the Android version. More discussion on this here: https://github.com/react-native-kit/react-native-track-player/issues/933