### PR TITLE
[ios] fix updating of remote commands

### DIFF
--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommand.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommand.swift
@@ -103,7 +103,7 @@ public struct FeedbackCommand: RemoteCommandProtocol {
     }
 }
 
-public enum RemoteCommand {
+public enum RemoteCommand : Equatable {
 
     case play
     

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommand.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommand.swift
@@ -128,6 +128,42 @@ public enum RemoteCommand : Equatable {
     case dislike(isActive: Bool, localizedTitle: String, localizedShortTitle: String)
     
     case bookmark(isActive: Bool, localizedTitle: String, localizedShortTitle: String)
+
+    var `case`: Case {
+      switch self {
+          case .play: return .play
+          case .pause: return .pause
+          case .stop: return .stop
+          case .togglePlayPause: return .togglePlayPause
+          case .next: return .next
+          case .previous: return .previous
+          case .changePlaybackPosition: return .changePlaybackPosition
+          case .skipForward: return .skipForward
+          case .skipBackward: return .skipBackward
+          case .like: return .like
+          case .dislike: return .dislike
+          case .bookmark: return .bookmark
+      }
+    }
+
+    enum Case {
+        case play
+        case pause
+        case stop
+        case togglePlayPause
+        case next
+        case previous
+        case changePlaybackPosition
+        case skipForward
+        case skipBackward
+        case like
+        case dislike
+        case bookmark
+    }
+
+    public static func ==(lhs: RemoteCommand, rhs: RemoteCommand) -> Bool {
+        return lhs.case == rhs.case
+    }
     
     /**
      All values in an array for convenience.

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommandController.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommandController.swift
@@ -30,9 +30,11 @@ public class RemoteCommandController {
     }
     
     internal func enable(commands: [RemoteCommand]) {
-        self.disable(commands: RemoteCommand.all())
-        commands.forEach { (command) in
-            self.enable(command: command)
+        RemoteCommand.all().forEach { (command) in
+            self.disable(command: command)
+            if commands.contains(command) {
+                self.enable(command: command);
+            }
         }
     }
     

--- a/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommandController.swift
+++ b/ios/RNTrackPlayer/Vendor/SwiftAudio/Classes/RemoteCommandController/RemoteCommandController.swift
@@ -32,8 +32,8 @@ public class RemoteCommandController {
     internal func enable(commands: [RemoteCommand]) {
         RemoteCommand.all().forEach { (command) in
             self.disable(command: command)
-            if commands.contains(command) {
-                self.enable(command: command);
+            if let newCommand = commands.first(where: {$0 == command}) {
+                self.enable(command: newCommand);
             }
         }
     }


### PR DESCRIPTION
I was looking into the following issue: https://github.com/react-native-kit/react-native-track-player/issues/921 where lock screen controls were ending up in a disabled state after calling `TrackPlayer.updateOptions`.

I compared the way `SwiftAudio` does enabling of commands with the way the Apple `NowPlaying` example code does it. Apple disables / reenables commands one by one, while SwiftAudio first disables all commands and then enables the ones that need to be enabled.

This also seems to solve the flashing of controls when calling `TrackPlayer.updateOptions`.