### PR TITLE
[iOS] Pass minBuffer as the buffer size.

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -110,7 +110,7 @@ If the player is already initialized, the promise will resolve instantly.
 | Param                | Type     | Description   | Default   | Android | iOS | Windows |
 | -------------------- | -------- | ------------- | --------- | :-----: | :-: | :-----: |
 | options              | `object` | The options   |
-| options.minBuffer    | `number` | Minimum time in seconds that needs to be buffered | 15 | ✓ | ✗ | ✗ |
+| options.minBuffer    | `number` | Minimum time in seconds that needs to be buffered | 15 | ✓ | ✓ | ✗ |
 | options.maxBuffer    | `number` | Maximum time in seconds that needs to be buffered | 50 | ✓ | ✗ | ✗ |
 | options.playBuffer   | `number` | Minimum time in seconds that needs to be buffered to start playing | 2.5 | ✓ | ✗ | ✗ |
 | options.backBuffer   | `number` | Time in seconds that should be kept in the buffer behind the current playhead time. | 0 | ✓ | ✗ | ✗ |

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -18,7 +18,6 @@ public class RNTrackPlayer: RCTEventEmitter {
 
     private lazy var player: RNTrackPlayerAudioPlayer = {
         let player = RNTrackPlayerAudioPlayer(reactEventEmitter: self)
-        player.bufferDuration = 1
         return player
     }()
     
@@ -148,6 +147,10 @@ public class RNTrackPlayer: RCTEventEmitter {
         // configure if player waits to play
         let autoWait: Bool = config["waitForBuffer"] as? Bool ?? false
         player.automaticallyWaitsToMinimizeStalling = autoWait
+        
+        // configure buffer size
+        let minBuffer: TimeInterval = config["minBuffer"] as? TimeInterval ?? 0
+        player.bufferDuration = minBuffer
         
         // configure audio session - category, options & mode
         var sessionCategory: AVAudioSession.Category = .playback


### PR DESCRIPTION
This has been suggested in a few issues (#440, #970) but it seems that nobody has actually submitted a change.