### PR TITLE
fix: added startForeground to onCreate

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -111,12 +111,21 @@ public class MusicService extends HeadlessJsTaskService {
         super.onStartCommand(intent, flags, startId);
         return START_NOT_STICKY;
     }
+    
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        String channel = Utils.getNotificationChannel((Context) this);
+        startForeground(1, new NotificationCompat.Builder(this, channel).build());
+    }
+
 
     @Override
     public void onDestroy() {
         super.onDestroy();
 
         destroy();
+        stopForeground(true);
     }
 
     @Override


### PR DESCRIPTION
resolve #620 #524 #473 #391

ANR graph changes since the fork was applied (released on 13 October 2020).
![image](https://user-images.githubusercontent.com/26326015/105537931-0812d080-5d36-11eb-9493-7d3a8a97dd11.png)
