### PR TITLE
removeEventListener implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,7 @@ declare namespace RNTrackPlayer {
 
   type EmitterSubscription = { remove: () => void; };
   export function addEventListener(type: EventType, listener: (data: any) => void): EmitterSubscription;
+  export function removeEventListener(type: EventType, listener: (data: any) => void): EmitterSubscription;
 
   export interface TrackMetadata {
     duration?: number;

--- a/lib/trackPlayer.js
+++ b/lib/trackPlayer.js
@@ -186,6 +186,7 @@ module.exports.registerEventHandler = registerEventHandler;
 module.exports.registerBackendService = registerPlaybackService;
 module.exports.registerPlaybackService = registerPlaybackService;
 module.exports.addEventListener = addEventListener;
+module.exports.removeEventListener = removeEventListener;
 
 // Player Queue Commands
 module.exports.add = add;

--- a/lib/trackPlayer.js
+++ b/lib/trackPlayer.js
@@ -92,6 +92,10 @@ function addEventListener(event, listener) {
     return emitter.addListener(event, listener);
 }
 
+function removeEventListener(event, listener) {
+    return emitter.removeListener(event, listener);
+}
+
 function warpEventResponse(handler, event, payload) {
     // transform into the old format and return to handler
     const additionalKeys = payload || {};


### PR DESCRIPTION
**removeEventListener** was implemented in order to use it to prevent the "_Can't perform a React state update on an unmounted component_"  warning.
