### PR TITLE
Update ProgressComponent documentation

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -476,6 +476,7 @@ Fired when an error occurs.
 ## Components
 #### `ProgressComponent`
 A component base that updates itself every second with a new position. Your app should extend it with a custom render.
+This component relies on the `componentDidMount` and `componentWillUnmmount` lifecycle methods. If using these methods in your component extending ProgressComponent, add `super.componentDidMount.apply(this)` and `super.componentWillUnmount.apply(this)` to the top of these methods.
 
 | State            | Type     | Description                      |
 | ---------------- | -------- | -------------------------------- |


### PR DESCRIPTION
Update ProgressComponent documentation to ensure people know to call  super.componentDidMount.apply(this) if they are overriding this method of the ProgressComponent. See #641 and #1128