### PR TITLE
Set canOverrideExistingModule to true

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -51,6 +51,11 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
         eventHandler = new MusicEvents(context);
         manager.registerReceiver(eventHandler, new IntentFilter(Utils.EVENT_INTENT));
     }
+    
+    @Override    
+    public boolean canOverrideExistingModule() {        
+        return true;    
+    }
 
     @Override
     public void onCatalystInstanceDestroy() {


### PR DESCRIPTION
Prevent crash the app asking to check `getPackages()` method in `MainApplication.java` because Native module `TrackPlayerModule` tried to override `MusicModule`.