### PR TITLE
Fix TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,6 +175,7 @@ declare namespace RNTrackPlayer {
   export const STATE_PAUSED: State;
   export const STATE_STOPPED: State;
   export const STATE_BUFFERING: State;
+  export const STATE_CONNECTING: State;
   export const STATE_READY: State;
 
   export const RATING_HEART: RatingType;
@@ -239,6 +240,6 @@ declare namespace RNTrackPlayer {
   export function usePlaybackStateIs(...states: State[]): boolean;
   export function useTrackPlayerProgress(
     interval?: number,
-    pollTrackPlayerStates?: State[],
+    pollTrackPlayerStates?: State[] | null,
   ): ProgressComponentState;
 }


### PR DESCRIPTION
The useTrackPlayerProgress hook can take `null` as the second argument
    to trigger polling regardless of the player's state, but the type
    definition for the hook does not allow null. This change adds null as
    an allowed value to the type definition.

The TypeScript definitions do not currently include the STATE_CONNECTING
    player state. This change adds that constant to the definitions.