### PR TITLE
Workaround to fix Android crash #1096

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -349,8 +349,12 @@ public class MusicManager implements OnAudioFocusChangeListener {
 
         // Stop receiving audio becoming noisy events
         if(receivingNoisyEvents) {
-            service.unregisterReceiver(noisyReceiver);
-            receivingNoisyEvents = false;
+            try {
+                service.unregisterReceiver(noisyReceiver);
+                receivingNoisyEvents = false;
+            } catch (Exception ex) {
+                Log.e(Utils.LOG, "An error occurred while unregistering the noisyReceiver: ", ex);
+            }
         }
 
         // Release the playback resources


### PR DESCRIPTION
As reported in #1096, performing the cycle `TrackPlayer.setupPlayer()` followed by `TrackPlayer.destroy()` a bunch of times ends up crashing the app on Android, with the following traceback:

```
E unknown:ReactNative: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.os.Handler.post(java.lang.Runnable)' on a null object reference
E unknown:ReactNative: 	at com.guichaguri.trackplayer.service.MusicBinder.post(MusicBinder.java:22)
E unknown:ReactNative: 	at com.guichaguri.trackplayer.module.MusicModule.waitForConnection(MusicModule.java:94)
E unknown:ReactNative: 	at com.guichaguri.trackplayer.module.MusicModule.getState(MusicModule.java:462)
E unknown:ReactNative: 	at java.lang.reflect.Method.invoke(Native Method)
E unknown:ReactNative: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
E unknown:ReactNative: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
E unknown:ReactNative: 	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
E unknown:ReactNative: 	at android.os.Handler.handleCallback(Handler.java:883)
E unknown:ReactNative: 	at android.os.Handler.dispatchMessage(Handler.java:100)
E unknown:ReactNative: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
E unknown:ReactNative: 	at android.os.Looper.loop(Looper.java:237)
E unknown:ReactNative: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
E unknown:ReactNative: 	at java.lang.Thread.run(Thread.java:919)
```

The `TrackPlayer.destroy()` immediately before the crash was always displaying this log:

```
E RNTrackPlayer: java.lang.IllegalArgumentException: Receiver not registered: com.guichaguri.trackplayer.service.MusicManager$1@5ba3ff
E RNTrackPlayer: 	at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1489)
E RNTrackPlayer: 	at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1571)
E RNTrackPlayer: 	at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:675)
E RNTrackPlayer: 	at com.guichaguri.trackplayer.service.MusicManager.destroy(MusicManager.java:352)
E RNTrackPlayer: 	at com.guichaguri.trackplayer.service.MusicService.destroy(MusicService.java:56)
E RNTrackPlayer: 	at com.guichaguri.trackplayer.service.MusicBinder.destroy(MusicBinder.java:53)
E RNTrackPlayer: 	at com.guichaguri.trackplayer.module.MusicModule.destroy(MusicModule.java:168)
E RNTrackPlayer: 	at java.lang.reflect.Method.invoke(Native Method)
E RNTrackPlayer: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
E RNTrackPlayer: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
E RNTrackPlayer: 	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
E RNTrackPlayer: 	at android.os.Handler.handleCallback(Handler.java:883)
E RNTrackPlayer: 	at android.os.Handler.dispatchMessage(Handler.java:100)
E RNTrackPlayer: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
E RNTrackPlayer: 	at android.os.Looper.loop(Looper.java:237)
E RNTrackPlayer: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
E RNTrackPlayer: 	at java.lang.Thread.run(Thread.java:919)
```

Which corresponds to unregistring the receiver in `MusicManager.java:352`. I do not have a great understanding of what this is, but I think that failure in the cleanup is causing `MusicBinder.destroy` not to run completely, `MusicModule.java: 169` not to run and set the `binder` object to `null`, leading to a corrupt state.

After adding the `try/catch` I've re-run my player several times until getting the log statement `An error occurred while unregistering the noisyReceiver:` with the above exception. The next run (which would have caused the crash before), the player worked fine.

Let me know if there is anything else I can do.

Many thanks,
Ruben.