### PR TITLE
Removing redundant links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,6 @@ const start = async () => {
 start();
 ```
 
-If you want to get started with this module, check the [API](https://react-native-kit.github.io/react-native-track-player/api/) page.
-If you want detailed information about the API, check the [Documentation](https://react-native-kit.github.io/react-native-track-player/documentation/).
-
 ## Core Team ✨
 
 <table>


### PR DESCRIPTION
Removed the link to old docs (react-native-kit.github.io) as it was creating confusion. 
Also, the same was already updated with new docs link and this was just redundant.
