### PR TITLE
Fix add() unable to insert before first track

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ async function add(tracks: Track | Track[], insertBeforeIndex?: number): Promise
   }
 
   // Note: we must be careful about passing nulls to non nullable parameters on Android.
-  return TrackPlayer.add(tracks, insertBeforeIndex || -1)
+  return TrackPlayer.add(tracks, insertBeforeIndex === undefined ? -1 : insertBeforeIndex)
 }
 
 async function remove(tracks: number | number[]): Promise<void> {


### PR DESCRIPTION
Calling `TrackPlayer.add(tracks, 0)` in order to add new tracks before the first track in the queue is currently broken due to 0 being falsy, thus defaulting to -1, and the tracks being added after the last track in the queue instead.  This change fixes that by explicitly checking for `undefined`, passing -1 in that case, and otherwise passing the number (including 0) on to the native code.