### PR TITLE
Remove player from notification when destroying track player on iOs

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -11,9 +11,9 @@ import MediaPlayer
 
 @objc(RNTrackPlayer)
 public class RNTrackPlayer: RCTEventEmitter {
-    
+
     // MARK: - Attributes
-    
+
     private var hasInitialized = false
 
     private lazy var player: RNTrackPlayerAudioPlayer = {
@@ -21,19 +21,19 @@ public class RNTrackPlayer: RCTEventEmitter {
         player.bufferDuration = 1
         return player
     }()
-    
+
     // MARK: - Lifecycle Methods
-    
+
     deinit {
         reset(resolve: { _ in }, reject: { _, _, _  in })
     }
-    
+
     // MARK: - RCTEventEmitter
-    
+
     override public static func requiresMainQueueSetup() -> Bool {
         return true;
     }
-    
+
     @objc(constantsToExport)
     override public func constantsToExport() -> [AnyHashable: Any] {
         return [
@@ -43,13 +43,13 @@ public class RNTrackPlayer: RCTEventEmitter {
             "STATE_PAUSED": AVPlayerWrapperState.paused.rawValue,
             "STATE_STOPPED": AVPlayerWrapperState.idle.rawValue,
             "STATE_BUFFERING": AVPlayerWrapperState.loading.rawValue,
-            
+
             "TRACK_PLAYBACK_ENDED_REASON_END": PlaybackEndedReason.playedUntilEnd.rawValue,
             "TRACK_PLAYBACK_ENDED_REASON_JUMPED": PlaybackEndedReason.jumpedToIndex.rawValue,
             "TRACK_PLAYBACK_ENDED_REASON_NEXT": PlaybackEndedReason.skippedToNext.rawValue,
             "TRACK_PLAYBACK_ENDED_REASON_PREVIOUS": PlaybackEndedReason.skippedToPrevious.rawValue,
             "TRACK_PLAYBACK_ENDED_REASON_STOPPED": PlaybackEndedReason.playerStopped.rawValue,
-            
+
             "PITCH_ALGORITHM_LINEAR": PitchAlgorithm.linear.rawValue,
             "PITCH_ALGORITHM_MUSIC": PitchAlgorithm.music.rawValue,
             "PITCH_ALGORITHM_VOICE": PitchAlgorithm.voice.rawValue,
@@ -71,7 +71,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             "CAPABILITY_BOOKMARK": Capability.bookmark.rawValue,
         ]
     }
-    
+
     @objc(supportedEvents)
     override public func supportedEvents() -> [String] {
         return [
@@ -79,7 +79,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             "playback-state",
             "playback-error",
             "playback-track-changed",
-            
+
             "remote-stop",
             "remote-pause",
             "remote-play",
@@ -94,7 +94,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             "remote-bookmark",
         ]
     }
-    
+
     func setupInterruptionHandling() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.removeObserver(self)
@@ -103,7 +103,7 @@ public class RNTrackPlayer: RCTEventEmitter {
                                        name: AVAudioSession.interruptionNotification,
                                        object: nil)
     }
-    
+
     @objc func handleInterruption(notification: Notification) {
         guard let userInfo = notification.userInfo,
             let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
@@ -138,20 +138,20 @@ public class RNTrackPlayer: RCTEventEmitter {
     }
 
     // MARK: - Bridged Methods
-    
+
     @objc(setupPlayer:resolver:rejecter:)
     public func setupPlayer(config: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if hasInitialized {
             resolve(NSNull())
             return
         }
-        
+
         setupInterruptionHandling();
 
         // configure if player waits to play
         let autoWait: Bool = config["waitForBuffer"] as? Bool ?? false
         player.automaticallyWaitsToMinimizeStalling = autoWait
-        
+
         // configure audio session - category, options & mode
         var sessionCategory: AVAudioSession.Category = .playback
         var sessionCategoryOptions: AVAudioSession.CategoryOptions = []
@@ -162,120 +162,123 @@ public class RNTrackPlayer: RCTEventEmitter {
             let mappedCategory = SessionCategory(rawValue: sessionCategoryStr) {
                 sessionCategory = mappedCategory.mapConfigToAVAudioSessionCategory()
         }
-        
+
         let sessionCategoryOptsStr = config["iosCategoryOptions"] as? [String]
         let mappedCategoryOpts = sessionCategoryOptsStr?.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() } ?? []
         sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
-        
+
         if
             let sessionCategoryModeStr = config["iosCategoryMode"] as? String,
             let mappedCategoryMode = SessionCategoryMode(rawValue: sessionCategoryModeStr) {
                 sessionCategoryMode = mappedCategoryMode.mapConfigToAVAudioSessionCategoryMode()
         }
-        
+
         // Progressively opt into AVAudioSession policies for background audio
         if #available(iOS 11.0, *) {
             var sessionCategoryPolicy: AVAudioSession.RouteSharingPolicy = .default
-            
+
             if
                 let sessionCategoryPolicyStr = config["iosCategoryPolicy"] as? String,
                 let mappedCategoryPolicy = SessionCategoryPolicy(rawValue: sessionCategoryPolicyStr) {
                     sessionCategoryPolicy = mappedCategoryPolicy.mapConfigToAVAudioSessionCategoryPolicy()
             }
-            
+
             try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, policy: sessionCategoryPolicy, options: sessionCategoryOptions)
         } else {
             try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, options: sessionCategoryOptions)
-        }        
+        }
         // setup event listeners
         player.remoteCommandController.handleChangePlaybackPositionCommand = { [weak self] event in
             if let event = event as? MPChangePlaybackPositionCommandEvent {
                 self?.sendEvent(withName: "remote-seek", body: ["position": event.positionTime])
                 return MPRemoteCommandHandlerStatus.success
             }
-            
+
             return MPRemoteCommandHandlerStatus.commandFailed
         }
-        
+
         player.remoteCommandController.handleNextTrackCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-next", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handlePauseCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-pause", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handlePlayCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-play", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handlePreviousTrackCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-previous", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handleSkipBackwardCommand = { [weak self] event in
             if let command = event.command as? MPSkipIntervalCommand,
                 let interval = command.preferredIntervals.first {
                 self?.sendEvent(withName: "remote-jump-backward", body: ["interval": interval])
                 return MPRemoteCommandHandlerStatus.success
             }
-            
+
             return MPRemoteCommandHandlerStatus.commandFailed
         }
-        
+
         player.remoteCommandController.handleSkipForwardCommand = { [weak self] event in
             if let command = event.command as? MPSkipIntervalCommand,
                 let interval = command.preferredIntervals.first {
                 self?.sendEvent(withName: "remote-jump-forward", body: ["interval": interval])
                 return MPRemoteCommandHandlerStatus.success
             }
-            
+
             return MPRemoteCommandHandlerStatus.commandFailed
         }
-        
+
         player.remoteCommandController.handleStopCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-stop", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handleTogglePlayPauseCommand = { [weak self] _ in
             if self?.player.playerState == .paused {
                 self?.sendEvent(withName: "remote-play", body: nil)
                 return MPRemoteCommandHandlerStatus.success
             }
-            
+
             self?.sendEvent(withName: "remote-pause", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handleLikeCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-like", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handleDislikeCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-dislike", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         player.remoteCommandController.handleBookmarkCommand = { [weak self] _ in
             self?.sendEvent(withName: "remote-bookmark", body: nil)
             return MPRemoteCommandHandlerStatus.success
         }
-        
+
         hasInitialized = true
         resolve(NSNull())
     }
-    
+
     @objc(destroy)
     public func destroy() {
         print("Destroying player")
+        self.player.stop()
+        self.player.nowPlayingInfoController.clear()
+        try? AVAudioSession.sharedInstance().setActive(false)
     }
-    
+
     @objc(updateOptions:resolver:rejecter:)
     public func update(options: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
 
@@ -284,7 +287,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             capabilitiesStr.append("togglePlayPause");
         }
         let capabilities = capabilitiesStr.compactMap { Capability(rawValue: $0) }
-        
+
         let remoteCommands = capabilities.map { capability in
             capability.mapToPlayerCommand(jumpInterval: options["jumpInterval"] as? NSNumber,
                                           likeOptions: options["likeOptions"] as? [String: Any],
@@ -293,12 +296,12 @@ public class RNTrackPlayer: RCTEventEmitter {
         }
 
         player.enableRemoteCommands(remoteCommands)
-        
+
         resolve(NSNull())
     }
-    
+
     @objc(add:before:resolver:rejecter:)
-    public func add(trackDicts: [[String: Any]], before trackId: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {        
+    public func add(trackDicts: [[String: Any]], before trackId: String?, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             UIApplication.shared.beginReceivingRemoteControlEvents();
         }
@@ -309,38 +312,38 @@ public class RNTrackPlayer: RCTEventEmitter {
                 reject("invalid_track_object", "Track is missing a required key", nil)
                 return
             }
-            
+
             tracks.append(track)
         }
-        
+
         print("Adding tracks:", tracks)
-        
+
         if let trackId = trackId {
             guard let insertIndex = player.items.firstIndex(where: { ($0 as! Track).id == trackId })
             else {
                 reject("track_not_in_queue", "Given track ID was not found in queue", nil)
                 return
             }
-            
+
             try? player.add(items: tracks, at: insertIndex)
         } else {
             try? player.add(items: tracks, playWhenReady: false)
         }
-        
+
         resolve(NSNull())
     }
-    
+
     @objc(remove:resolver:rejecter:)
     public func remove(tracks ids: [String], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Removing tracks:", ids)
-        
+
         // Look through queue for tracks that match one of the provided ids.
-        // Do this in reverse order so that as they are removed, 
+        // Do this in reverse order so that as they are removed,
         // it will not affect other indices that will be removed.
         for (index, element) in player.items.enumerated().reversed() {
             // skip the current index
             if index == player.currentIndex { continue }
-            
+
             let track = element as! Track
             if ids.contains(track.id) {
                 try? player.removeItem(at: index)
@@ -349,14 +352,14 @@ public class RNTrackPlayer: RCTEventEmitter {
 
         resolve(NSNull())
     }
-    
+
     @objc(removeUpcomingTracks:rejecter:)
     public func removeUpcomingTracks(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Removing upcoming tracks")
         player.removeUpcomingItems()
         resolve(NSNull())
     }
-    
+
     @objc(skip:resolver:rejecter:)
     public func skip(to trackId: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         guard let trackIndex = player.items.firstIndex(where: { ($0 as! Track).id == trackId })
@@ -364,12 +367,12 @@ public class RNTrackPlayer: RCTEventEmitter {
             reject("track_not_in_queue", "Given track ID was not found in queue", nil)
             return
         }
-        
+
         print("Skipping to track:", trackId)
         try? player.jumpToItem(atIndex: trackIndex, playWhenReady: player.playerState == .playing)
         resolve(NSNull())
     }
-    
+
     @objc(skipToNext:rejecter:)
     public func skipToNext(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Skipping to next track")
@@ -380,7 +383,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             reject("queue_exhausted", "There is no tracks left to play", nil)
         }
     }
-    
+
     @objc(skipToPrevious:rejecter:)
     public func skipToPrevious(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Skipping to next track")
@@ -391,7 +394,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             reject("no_previous_track", "There is no previous track", nil)
         }
     }
-    
+
     @objc(reset:rejecter:)
     public func reset(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Resetting player.")
@@ -401,7 +404,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             UIApplication.shared.endReceivingRemoteControlEvents();
         }
     }
-    
+
     @objc(play:rejecter:)
     public func play(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Starting/Resuming playback")
@@ -409,54 +412,54 @@ public class RNTrackPlayer: RCTEventEmitter {
         player.play()
         resolve(NSNull())
     }
-    
+
     @objc(pause:rejecter:)
     public func pause(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Pausing playback")
         player.pause()
         resolve(NSNull())
     }
-    
+
     @objc(stop:rejecter:)
     public func stop(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Stopping playback")
         player.stop()
         resolve(NSNull())
     }
-    
+
     @objc(seekTo:resolver:rejecter:)
     public func seek(to time: Double, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Seeking to \(time) seconds")
         player.seek(to: time)
         resolve(NSNull())
     }
-    
+
     @objc(setVolume:resolver:rejecter:)
     public func setVolume(level: Float, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Setting volume to \(level)")
         player.volume = level
         resolve(NSNull())
     }
-    
+
     @objc(getVolume:rejecter:)
     public func getVolume(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Getting current volume")
         resolve(player.volume)
     }
-    
+
     @objc(setRate:resolver:rejecter:)
     public func setRate(rate: Float, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Setting rate to \(rate)")
         player.rate = rate
         resolve(NSNull())
     }
-    
+
     @objc(getRate:rejecter:)
     public func getRate(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Getting current rate")
         resolve(player.rate)
     }
-    
+
     @objc(getTrack:resolver:rejecter:)
     public func getTrack(id: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         guard let track = player.items.first(where: { ($0 as! Track).id == id })
@@ -464,41 +467,41 @@ public class RNTrackPlayer: RCTEventEmitter {
             reject("track_not_in_queue", "Given track ID was not found in queue", nil)
             return
         }
-        
+
         resolve((track as? Track)?.toObject())
     }
-    
+
     @objc(getQueue:rejecter:)
     public func getQueue(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         let serializedQueue = player.items.map { ($0 as! Track).toObject() }
         resolve(serializedQueue)
     }
-    
+
     @objc(getCurrentTrack:rejecter:)
     public func getCurrentTrack(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         resolve((player.currentItem as? Track)?.id)
     }
-    
+
     @objc(getDuration:rejecter:)
     public func getDuration(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         resolve(player.duration)
     }
-    
+
     @objc(getBufferedPosition:rejecter:)
     public func getBufferedPosition(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         resolve(player.bufferedPosition)
     }
-    
+
     @objc(getPosition:rejecter:)
     public func getPosition(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         resolve(player.currentTime)
     }
-    
+
     @objc(getState:rejecter:)
     public func getState(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         resolve(player.playerState.rawValue)
     }
-    
+
     @objc(updateMetadataForTrack:properties:resolver:rejecter:)
     public func updateMetadata(for trackId: String, properties: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         guard let track = player.items.first(where: { ($0 as! Track).id == trackId }) as? Track
@@ -506,7 +509,7 @@ public class RNTrackPlayer: RCTEventEmitter {
                 reject("track_not_in_queue", "Given track ID was not found in queue", nil)
                 return
         }
-        
+
         track.updateMetadata(dictionary: properties)
         if (player.currentItem as! Track).id == track.id {
             player.nowPlayingInfoController.set(keyValues: [


### PR DESCRIPTION
There were an issue destroying player on iOs ( tracked here [#886](https://github.com/DoubleSymmetry/react-native-track-player/issues/886) ), the destroy method didn't seemed to be linked to any code (except the print).

So I just followed instructions from a SwiftAudio issue (https://github.com/jorgenhenrichsen/SwiftAudio/issues/83#issuecomment-575966626) and seems to be working now for iOs.