### PR TITLE
Remove player from notification when destroying track player on iOs

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -274,6 +274,9 @@ public class RNTrackPlayer: RCTEventEmitter {
     @objc(destroy)
     public func destroy() {
         print("Destroying player")
+        self.player.stop()
+        self.player.nowPlayingInfoController.clear()
+        try? AVAudioSession.sharedInstance().setActive(false)
     }
     
     @objc(updateOptions:resolver:rejecter:)


### PR DESCRIPTION
There were an issue destroying player on iOs ( tracked here [#886](https://github.com/DoubleSymmetry/react-native-track-player/issues/886) ), the destroy method didn't seemed to be linked to any code (except the print).

So I just followed instructions from a SwiftAudio issue (https://github.com/jorgenhenrichsen/SwiftAudio/issues/83#issuecomment-575966626) and seems to be working now for iOs.