### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,7 @@ module.exports = async function() {
 ### Adding Tracks to the Playback Queue
 You can add a track to the player using a url or by requiring a file in the app bundle or on the file system.
 
-First of all, you need to create a [track object](https://react-native-kit.github.io/react-native-track-player/documentation/#track-object), which is a plain javascript object with a number of properties describing the track. Then [add](https://react-native-kit.github.io/react-native-track-player/documentation/#addtracks-insertbeforeid) the track to the queue:
+First of all, you need to create a [track object](https://react-native-track-player.js.org/react-native-track-player/documentation/#track-object), which is a plain javascript object with a number of properties describing the track. Then [add](https://react-native-track-player.js.org/react-native-track-player/documentation/#addtracks-insertbeforeid) the track to the queue:
 
 ```typescript
 var track = {
@@ -68,7 +68,7 @@ const track3 = {
     duration: 411
 };
 
-// You can then [add](https://react-native-kit.github.io/react-native-track-player/documentation/#addtracks-insertbeforeindex) the items to the queue
+// You can then [add](https://react-native-track-player.js.org/react-native-track-player/documentation/#addtracks-insertbeforeindex) the items to the queue
 await TrackPlayer.add([track1, track2, track3]);
 ```
 
@@ -127,7 +127,7 @@ console.log(`First title: ${tracks[0].title}`);
 ```
 #### Playback Events
 
-You can subscribe to [player events](https://react-native-kit.github.io/react-native-track-player/documentation/#player), which describe the changing nature of the playback state. For example, subscribe to the `Event.PlaybackTrackChanged` event to be notified when the track has changed or subscribe to the `Event.PlaybackState` event to be notified when the player buffers, plays, pauses and stops.
+You can subscribe to [player events](https://react-native-track-player.js.org/react-native-track-player/documentation/#player), which describe the changing nature of the playback state. For example, subscribe to the `Event.PlaybackTrackChanged` event to be notified when the track has changed or subscribe to the `Event.PlaybackState` event to be notified when the player buffers, plays, pauses and stops.
 
 #### Example
 ```tsx
@@ -158,7 +158,7 @@ The playback service keeps running even when the app is in the background. It wi
 
 #### Remote Events
 
-[Remote events](https://react-native-kit.github.io/react-native-track-player/documentation/#media-controls) are sent from places outside of our user interface that we can react to. For example if the user presses the pause media control in the IOS lockscreen / Android notification or from their Bluetooth headset, we want to have TrackPlayer pause the audio.
+[Remote events](https://react-native-track-player.js.org/react-native-track-player/documentation/#media-controls) are sent from places outside of our user interface that we can react to. For example if the user presses the pause media control in the IOS lockscreen / Android notification or from their Bluetooth headset, we want to have TrackPlayer pause the audio.
 
 If you create a listener to a remote event like `remote-pause` in the context of a React component, there is a chance the UI will be unmounted automatically when the app is in the background, causing it to be missed. For this reason it is best to place remote listeners in the playback service, since it will keep running even when the app is in the background.
 
@@ -215,7 +215,7 @@ Track Player can be configured using a number of options. Some of these options 
 
 You can change options multiple times. You do not need to specify all the options, just the ones you want to change.
 
-For more information about the properties you can set, [check the documentation](https://react-native-kit.github.io/react-native-track-player/documentation/#updateoptionsdata).
+For more information about the properties you can set, [check the documentation](https://react-native-track-player.js.org/react-native-track-player/documentation/#updateoptionsdata).
 
 #### Example
 

--- a/docs/Background-Mode.md
+++ b/docs/Background-Mode.md
@@ -20,7 +20,7 @@ TrackPlayer.updateOptions({
 });
 ```
 
-Please note that while your app is in background, your UI might be unmounted by React Native. Event listeners added in the [playback service](https://react-native-kit.github.io/react-native-track-player/api/#playback-service) will continue to receive events.
+Please note that while your app is in background, your UI might be unmounted by React Native. Event listeners added in the [playback service](https://react-native-track-player.js.org/react-native-track-player/api/#playback-service) will continue to receive events.
 
 ### Notification
 The notification will be visible as long as the playback service runs. Your app will be opened when it is clicked. You can implement a custom initialization (e.g.: opening directly the player UI) by using the [Linking API](https://facebook.github.io/react-native/docs/linking) looking for the `trackplayer://notification.click` URI.

--- a/docs/Platform-Support.md
+++ b/docs/Platform-Support.md
@@ -45,7 +45,7 @@ permalink: /platform-support/
 | Caching | ✓ | ✗ | ✗ |
 | Background Mode¹ | ✓ | ✓ | ✓ |
 
-¹: Read more in [Background Mode](https://react-native-kit.github.io/react-native-track-player/background/)
+¹: Read more in [Background Mode](https://react-native-track-player.js.org/react-native-track-player/background/)
 
 ## Functions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,8 +33,8 @@ A fully fledged audio module created for music apps. Provides audio playback, ex
 
 ## Example
 
-If you want to get started with this module, check the [Getting Started](https://react-native-kit.github.io/react-native-track-player/api/) page.
-If you want detailed information about the API, check the [Documentation](https://react-native-kit.github.io/react-native-track-player/documentation/).
+If you want to get started with this module, check the [Getting Started](https://react-native-track-player.js.org/react-native-track-player/api/) page.
+If you want detailed information about the API, check the [Documentation](https://react-native-track-player.js.org/react-native-track-player/documentation/).
 You can also look at our example project [here](https://github.com/react-native-kit/react-native-track-player/tree/master/example).
 
 ```javascript


### PR DESCRIPTION
Hello, it seems like there are some broken links in the documentation e.g. Track Object on this page.
https://react-native-track-player.js.org/getting-started/#playback-service

This PR changes the absolute links from https://react-native-kit.github.io to https://react-native-track-player.js.org

Have a great day
Lily
