### PR TITLE
Feature: Specify Separate Jump Intervals (backport for v1)

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/ButtonEvents.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/ButtonEvents.java
@@ -113,14 +113,14 @@ public class ButtonEvents extends MediaSessionCompat.Callback {
     @Override
     public void onRewind() {
         Bundle bundle = new Bundle();
-        bundle.putInt("interval", manager.getMetadata().getJumpInterval());
+        bundle.putInt("interval", manager.getMetadata().getBackwardJumpInterval());
         service.emit(MusicEvents.BUTTON_JUMP_BACKWARD, bundle);
     }
 
     @Override
     public void onFastForward() {
         Bundle bundle = new Bundle();
-        bundle.putInt("interval", manager.getMetadata().getJumpInterval());
+        bundle.putInt("interval", manager.getMetadata().getForwardJumpInterval());
         service.emit(MusicEvents.BUTTON_JUMP_FORWARD, bundle);
     }
 

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -44,6 +44,8 @@ public class MetadataManager {
 
     private int ratingType = RatingCompat.RATING_NONE;
     private int jumpInterval = 15;
+    private int forwardJumpInterval = 0;
+    private int backwardJumpInterval = 0;
     private long actions = 0;
     private long compactActions = 0;
     private SimpleTarget<Bitmap> artworkTarget;
@@ -145,6 +147,8 @@ public class MetadataManager {
 
         // Update the jump interval
         jumpInterval = Utils.getInt(options, "jumpInterval", 15);
+        forwardJumpInterval = Utils.getInt(options, "forwardJumpInterval", jumpInterval);
+        backwardJumpInterval = Utils.getInt(options, "backwardJumpInterval", jumpInterval);
 
         // Update the rating type
         ratingType = Utils.getInt(options, "ratingType", RatingCompat.RATING_NONE);
@@ -157,7 +161,15 @@ public class MetadataManager {
         return ratingType;
     }
 
-    public int getJumpInterval() {
+    public int getForwardJumpInterval() {
+        if (forwardJumpInterval > 0) return forwardJumpInterval;
+        if (backwardJumpInterval > 0) return backwardJumpInterval;
+        return jumpInterval;
+    }
+
+    public int getBackwardJumpInterval() {
+        if (backwardJumpInterval > 0) return backwardJumpInterval;
+        if (forwardJumpInterval > 0) return forwardJumpInterval;
         return jumpInterval;
     }
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -248,6 +248,8 @@ Some parameters are unused depending on platform.
 | options      | `object`   | The options |
 | options.ratingType | [Rating Constant](#rating) | The rating type | ✓ | ✗ | ✗ |
 | options.jumpInterval | `number` | The interval in seconds for the jump forward/backward buttons | ✓ | ✓ | ✓ |
+| options.forwardJumpInterval | `number` | The interval in seconds for the jump forward buttons (if not given, backwardJumpInterval value will be used, if it's not given too, jumpInterval value will be used as fallback) | ✓ | ✓ | ✗ |
+| options.backwardJumpInterval | `number` | The interval in seconds for the jump backward buttons (if not given, forwardJumpInterval value will be used, if it's not given too, jumpInterval value will be used as fallback) | ✓ | ✓ | ✓ |
 | options.stopWithApp | `boolean` | Whether the player will be destroyed when the app closes | ✓ | ✗ | ✗ |
 | options.alwaysPauseOnInterruption | `boolean` | Whether the `remote-duck` event will be triggered on every interruption | ✓ | ✗ | ✗ |
 | options.capabilities | `array` of [Capability Constants](#capability) | The media controls that will be enabled | ✓ | ✓ | ✓ |
@@ -404,14 +406,14 @@ Fired when the user presses the jump forward button. Only fired if the `CAPABILI
 
 | Param    | Type     | Description   |
 | -------- | -------- | ------------- |
-| interval | `number` | The number of seconds to jump forward. It's usually the `jumpInterval` set in the options. |
+| interval | `number` | The number of seconds to jump forward. It's usually the `forwardJumpInterval` set in the options. |
 
 #### `remote-jump-backward`
 Fired when the user presses the jump backward button. Only fired if the `CAPABILITY_JUMP_BACKWARD` is allowed.
 
 | Param    | Type     | Description   |
 | -------- | -------- | ------------- |
-| interval | `number` | The number of seconds to jump backward. It's usually the `jumpInterval` set in the options. |
+| interval | `number` | The number of seconds to jump backward. It's usually the `backwardJumpInterval` set in the options. |
 
 #### `remote-duck`
 Subscribing to this event to handle interruptions ensures that your app’s audio continues behaving gracefully when a phone call arrives, a clock or calendar alarm sounds, or another app plays audio.

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,6 +95,8 @@ declare namespace RNTrackPlayer {
   export interface MetadataOptions {
     ratingType?: RatingType;
     jumpInterval?: number;
+    forwardJumpInterval?: number;
+    backwardJumpInterval?: number;
     likeOptions?: FeedbackOptions;
     dislikeOptions?: FeedbackOptions;
     bookmarkOptions?: FeedbackOptions;

--- a/ios/RNTrackPlayer/Models/Capabilities.swift
+++ b/ios/RNTrackPlayer/Models/Capabilities.swift
@@ -12,6 +12,8 @@ enum Capability: String {
     case play, pause, togglePlayPause, stop, next, previous, jumpForward, jumpBackward, seek, like, dislike, bookmark
     
     func mapToPlayerCommand(jumpInterval: NSNumber?,
+                            forwardJumpInterval: NSNumber?,
+                            backwardJumpInterval: NSNumber?,
                             likeOptions: [String: Any]?,
                             dislikeOptions: [String: Any]?,
                             bookmarkOptions: [String: Any]?) -> RemoteCommand {
@@ -31,9 +33,9 @@ enum Capability: String {
         case .seek:
             return .changePlaybackPosition
         case .jumpForward:
-            return .skipForward(preferredIntervals: [jumpInterval ?? 15])
+            return .skipForward(preferredIntervals: [((forwardJumpInterval ?? backwardJumpInterval) ?? jumpInterval) ?? 15])
         case .jumpBackward:
-            return .skipBackward(preferredIntervals: [jumpInterval ?? 15])
+            return .skipBackward(preferredIntervals: [((backwardJumpInterval ?? forwardJumpInterval) ?? jumpInterval) ?? 15])
         case .like:
             return .like(isActive: likeOptions?["isActive"] as? Bool ?? false,
                          localizedTitle: likeOptions?["title"] as? String ?? "Like",

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -287,6 +287,8 @@ public class RNTrackPlayer: RCTEventEmitter {
         
         let remoteCommands = capabilities.map { capability in
             capability.mapToPlayerCommand(jumpInterval: options["jumpInterval"] as? NSNumber,
+                                          forwardJumpInterval: options["forwardJumpInterval"] as? NSNumber,
+                                          backwardJumpInterval: options["backwardJumpInterval"] as? NSNumber,
                                           likeOptions: options["likeOptions"] as? [String: Any],
                                           dislikeOptions: options["dislikeOptions"] as? [String: Any],
                                           bookmarkOptions: options["bookmarkOptions"] as? [String: Any])

--- a/windows/RNTrackPlayer/Logic/Metadata.cs
+++ b/windows/RNTrackPlayer/Logic/Metadata.cs
@@ -10,6 +10,8 @@ namespace TrackPlayer.Logic
         private MediaManager manager;
         private SystemMediaTransportControls controls;
         private double jumpInterval = 15;
+        private double forwardJumpInterval = null;
+        private double backwardJumpInterval = null;
         private bool play, pause, stop, previous, next, jumpForward, jumpBackward, seek;
 
         public Metadata(MediaManager manager)
@@ -62,6 +64,16 @@ namespace TrackPlayer.Logic
             if (data.TryGetValue("jumpInterval", out var ji))
             {
                 jumpInterval = (double)ji;
+            }
+
+            if (data.TryGetValue("forwardJumpInterval", out var ji))
+            {
+                forwardJumpInterval = (double)ji;
+            }
+
+            if (data.TryGetValue("backwardJumpInterval", out var ji))
+            {
+                backwardJumpInterval = (double)ji;
             }
 
             if (data.TryGetValue("capabilities", out var caps))
@@ -137,12 +149,12 @@ namespace TrackPlayer.Logic
                 case SystemMediaTransportControlsButton.FastForward:
                     eventType = Events.ButtonJumpForward;
                     data = new JObject();
-                    data["interval"] = jumpInterval;
+                    data["interval"] = forwardJumpInterval ?? backwardJumpInterval ?? jumpInterval;
                     break;
                 case SystemMediaTransportControlsButton.Rewind:
                     eventType = Events.ButtonJumpBackward;
                     data = new JObject();
-                    data["interval"] = jumpInterval;
+                    data["interval"] = backwardJumpInterval ?? forwardJumpInterval ?? jumpInterval;
                     break;
                 default:
                     return;


### PR DESCRIPTION
This is a backport of https://github.com/DoubleSymmetry/react-native-track-player/pull/1177 for v1.
Compared to the original PR, I've reverted deleting `jumpInterval` which is now used as fallback so that this would not be breaking change.

I've tested it on android and ios, but I'm not sure that windows version is fine (I'm also not familiar with C#, just googled some syntax)