### PR TITLE
Fix: Regression in Update Metadata Artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ To install release candidates run `yarn add react-native-track-player@next`
   [#473](https://github.com/DoubleSymmetry/react-native-track-player/issues/473)
   [#391](https://github.com/DoubleSymmetry/react-native-track-player/issues/391)
 
-* Fix issue updating artwork on `updateMetadata` and `updateNowPlayingMetadata`
+* Fix regression in updating artwork on `updateMetadata` and `updateNowPlayingMetadata`
   [dcvz](https://github.com/dcvz)
+  [#662](https://github.com/DoubleSymmetry/react-native-track-player/issues/662#issuecomment-896370375)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,6 @@ To install release candidates run `yarn add react-native-track-player@next`
   [#473](https://github.com/DoubleSymmetry/react-native-track-player/issues/473)
   [#391](https://github.com/DoubleSymmetry/react-native-track-player/issues/391)
 
+* Fix issue updating artwork on `updateMetadata` and `updateNowPlayingMetadata`
+  [dcvz](https://github.com/dcvz)
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,12 @@ async function updateOptions(options: MetadataOptions = {}): Promise<void> {
 }
 
 async function updateMetadataForTrack(trackIndex: number, metadata: TrackMetadataBase): Promise<void> {
+  // Clone the object before modifying it
+  metadata = Object.assign({}, metadata)
+
+  // Resolve the artowork URL
+  metadata.artwork = resolveImportedPath(metadata.artwork)
+
   return TrackPlayer.updateMetadataForTrack(trackIndex, metadata)
 }
 
@@ -124,6 +130,12 @@ function clearNowPlayingMetadata(): Promise<void> {
 }
 
 function updateNowPlayingMetadata(metadata: NowPlayingMetadata): Promise<void> {
+  // Clone the object before modifying it
+  metadata = Object.assign({}, metadata)
+
+  // Resolve the artowork URL
+  metadata.artwork = resolveImportedPath(metadata.artwork)
+
   return TrackPlayer.updateNowPlayingMetadata(metadata)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ async function updateMetadataForTrack(trackIndex: number, metadata: TrackMetadat
   // Clone the object before modifying it
   metadata = Object.assign({}, metadata)
 
-  // Resolve the artowork URL
+  // Resolve the artwork URL
   metadata.artwork = resolveImportedPath(metadata.artwork)
 
   return TrackPlayer.updateMetadataForTrack(trackIndex, metadata)
@@ -133,7 +133,7 @@ function updateNowPlayingMetadata(metadata: NowPlayingMetadata): Promise<void> {
   // Clone the object before modifying it
   metadata = Object.assign({}, metadata)
 
-  // Resolve the artowork URL
+  // Resolve the artwork URL
   metadata.artwork = resolveImportedPath(metadata.artwork)
 
   return TrackPlayer.updateNowPlayingMetadata(metadata)


### PR DESCRIPTION
Reported in https://github.com/DoubleSymmetry/react-native-track-player/issues/662#issuecomment-896370375