### PR TITLE
Fix the problem of violating react hook rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports =  {
     'plugin:@typescript-eslint/recommended',  // Uses the recommended rules from the @typescript-eslint/eslint-plugin
     'prettier/@typescript-eslint',  // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     'plugin:prettier/recommended',  // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'plugin:react-hooks/recommended',
   ],
  parserOptions:  {
     ecmaVersion:  2018,  // Allows for the parsing of modern ECMAScript features

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.2.0",
     "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^1.17.0",
     "rimraf": "^2.6.2",
     "typescript": "^3.2.4"

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -75,6 +75,13 @@ export function useProgress(updateInterval?: number) {
   const [state, setState] = useState<ProgressState>({ position: 0, duration: 0, buffered: 0 })
   const playerState = usePlaybackState()
   const stateRef = useRef(state)
+  const isUnmountedRef = useRef(true)
+  useEffect(() => {
+    isUnmountedRef.current = false
+    return () => {
+      isUnmountedRef.current = true
+    }
+  }, [])
 
   const getProgress = async () => {
     const [position, duration, buffered] = await Promise.all([
@@ -82,6 +89,8 @@ export function useProgress(updateInterval?: number) {
       TrackPlayer.getDuration(),
       TrackPlayer.getBufferedPosition(),
     ])
+    // After the asynchronous code is executed, if the component has been uninstalled, do not update the status
+    if (isUnmountedRef.current) return
 
     if (
       position === stateRef.current.position &&

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -58,7 +58,7 @@ export const useTrackPlayerEvents = (events: Event[], handler: Handler) => {
     )
 
     return () => subs.forEach(sub => sub.remove())
-  }, events)
+  }, [events])
 }
 
 export interface ProgressState {
@@ -106,7 +106,7 @@ export function useProgress(updateInterval?: number) {
 
     const poll = setInterval(getProgress, updateInterval || 1000)
     return () => clearInterval(poll)
-  }, [playerState])
+  }, [playerState, updateInterval])
 
   return state
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,6 +272,11 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
This PR did two things:
1. Fixed the problem of violating react hook rules
2. In order to avoid similar problems in the future, I added the official [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) eslint extension of react to check for problems that violate the rules of react hooks.
