### PR TITLE
Fix onTaskRemoved NullPointerException

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -132,7 +132,7 @@ public class MusicService extends HeadlessJsTaskService {
         super.onTaskRemoved(rootIntent);
 
         if (manager == null || manager.shouldStopWithApp()) {
-            if (manager != null) {
+            if (manager != null && manager.getPlayback() != null) {
                 manager.getPlayback().stop();
             }
             destroy();


### PR DESCRIPTION
This exception is thrown every time the app is closed from app recents, if a track had not played.

java.lang.RuntimeException: 
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:4163)
  at android.app.ActivityThread.access$1800 (ActivityThread.java:219)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1923)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7557)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:492)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:937)
Caused by: java.lang.NullPointerException: 
  at com.guichaguri.trackplayer.service.MusicService.onTaskRemoved (MusicService.java:136)
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:4147)