### PR TITLE
Reset initialization flag on destroy

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -292,6 +292,7 @@ public class RNTrackPlayer: RCTEventEmitter {
         self.player.stop()
         self.player.nowPlayingInfoController.clear()
         try? AVAudioSession.sharedInstance().setActive(false)
+        hasInitialized = false
     }
 
     @objc(updateOptions:resolver:rejecter:)


### PR DESCRIPTION
According to docs, calling `destroy()`:
`Destroys the player, cleaning up its resources. After executing this function, you won't be able to use the player anymore, unless you call setupPlayer() again.`

However since `hasInitialized` wasn't reset to false, it didn't run any setup code. This PR fixes the issue.

I noticed this while working on an app that plays and records sound multiple times. Since my recording code was messing with the shared instance, I needed a way to "restart" the track player.