### PR TITLE
Feat: Remove previous track on queue

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -355,6 +355,13 @@ public class RNTrackPlayer: RCTEventEmitter {
         resolve(NSNull())
     }
 
+    @objc(removePreviousTracks:rejecter:)
+    public func removePreviousTracks(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        print("Removing Previous tracks")
+        player.removePreviousItems()
+        resolve(NSNull())
+    }
+
     @objc(removeUpcomingTracks:rejecter:)
     public func removeUpcomingTracks(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         print("Removing upcoming tracks")

--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.m
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.m
@@ -30,6 +30,9 @@ RCT_EXTERN_METHOD(remove:(NSArray *)objects
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(removePreviousTracks:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject);
+
 RCT_EXTERN_METHOD(removeUpcomingTracks:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,10 @@ async function remove(tracks: number | number[]): Promise<void> {
   return TrackPlayer.remove(tracks)
 }
 
+async function removePreviousTracks(): Promise<void> {
+  return TrackPlayer.removePreviousTracks()
+}
+
 async function removeUpcomingTracks(): Promise<void> {
   return TrackPlayer.removeUpcomingTracks()
 }
@@ -228,6 +232,7 @@ export default {
   // MARK: - Queue API
   add,
   remove,
+  removePreviousTracks,
   removeUpcomingTracks,
   skip,
   skipToNext,


### PR DESCRIPTION
This feature will help to anyone who want implements their own shuffle mode. The reason of this method was built its because `.remove()` for iOS doesn't work as expected when trying to remove bulk tracks.