### PR TITLE
fix(package.json): react-native-windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
     "react-native": ">=0.60.0-rc.2",
     "react-native-windows": ">=0.63.0"
   },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/react-native": "^0.60.0",
     "@typescript-eslint/eslint-plugin": "^1.7.0",


### PR DESCRIPTION
Make `react-native-windows` and optional dependency. Fixes https://github.com/DoubleSymmetry/react-native-track-player/issues/1301