### PR TITLE
added jcenter to build grade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ import groovy.json.JsonSlurper
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
         google()
     }
     dependencies {
@@ -53,6 +54,7 @@ repositories {
     }
 
     mavenCentral()
+    jcenter()
     google()
 }
 


### PR DESCRIPTION
In new installations of react native, the android is giving an error due to the lack of jcenter()