### PR TITLE
Fix pendingIntent for android 12 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 
     // Make sure we're using androidx
     implementation "androidx.core:core:1.3.0-rc01"
-    implementation "androidx.media:media:1.1.0"
+    implementation "androidx.media:media:1.4.3"
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0-alpha01"
     implementation "com.github.bumptech.glide:glide:4.7.1"
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -57,9 +57,16 @@ public class MetadataManager {
         this.service = service;
         this.manager = manager;
 
+        Intent intent = new Intent(Intent.ACTION_MEDIA_BUTTON);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(
+                service,
+                0, intent,
+            (Build.VERSION.SDK_INT >= 23) ? PendingIntent.FLAG_IMMUTABLE : null
+        );
+
         String channel = Utils.getNotificationChannel((Context) service);
         this.builder = new NotificationCompat.Builder(service, channel);
-        this.session = new MediaSessionCompat(service, "TrackPlayer", null, null);
+        this.session = new MediaSessionCompat(service, "TrackPlayer", null, pendingIntent);
 
         session.setFlags(MediaSessionCompat.FLAG_HANDLES_QUEUE_COMMANDS);
         session.setCallback(new ButtonEvents(service, manager));
@@ -81,7 +88,11 @@ public class MetadataManager {
         openApp.setAction(Intent.ACTION_VIEW);
         openApp.setData(Uri.parse("trackplayer://notification.click"));
 
-        builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_CANCEL_CURRENT));
+        if (Build.VERSION.SDK_INT >= 23) {
+            builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE));
+        } else {
+            builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_CANCEL_CURRENT));
+        }
 
         builder.setSmallIcon(R.drawable.play);
         builder.setCategory(NotificationCompat.CATEGORY_TRANSPORT);


### PR DESCRIPTION
Fixes #1322. Required for Android 12 compatibility as well as #1269.

Without these, it'll fail to build for Android 12 or crash once loaded.