### PR TITLE
support for android 12 devices

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         </service>
 
         <!-- A receiver that will receive media buttons. Required on pre-lollipop devices -->
-        <receiver android:name="androidx.media.session.MediaButtonReceiver">
+        <receiver android:name="androidx.media.session.MediaButtonReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>


### PR DESCRIPTION
Fix for android 12 devices. 


The receiver should have "android.exported="true:" in order to support latest SDK versions