### PR TITLE
Fix getTrack return type.

### DIFF
--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -183,7 +183,7 @@ async function getRate(): Promise<number> {
   return TrackPlayer.getRate()
 }
 
-async function getTrack(trackIndex: number): Promise<Track> {
+async function getTrack(trackIndex: number): Promise<Track | null> {
   return TrackPlayer.getTrack(trackIndex)
 }
 


### PR DESCRIPTION
Adds `null` to the return type of `TrackPlayer.getTrack(index)`