### PR TITLE
Code Fix: add resolves index on ios

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -331,7 +331,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             tracks.append(track)
         }
 
-        var index
+        var index: Int = 0;
         if (trackIndex.intValue > player.items.count) {
             reject("index_out_of_bounds", "The track index is out of bounds", nil)
         } else if trackIndex.intValue == -1 { // -1 means no index was passed and therefore should be inserted at the end.

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -331,15 +331,17 @@ public class RNTrackPlayer: RCTEventEmitter {
             tracks.append(track)
         }
 
+        var index
         if (trackIndex.intValue > player.items.count) {
             reject("index_out_of_bounds", "The track index is out of bounds", nil)
         } else if trackIndex.intValue == -1 { // -1 means no index was passed and therefore should be inserted at the end.
+            index = player.items.count
             try? player.add(items: tracks, playWhenReady: false)
         } else {
+            index = trackIndex.intValue
             try? player.add(items: tracks, at: trackIndex.intValue)
         }
-
-        resolve(NSNull())
+        resolve(index)
     }
 
     @objc(remove:resolver:rejecter:)

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -331,7 +331,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             tracks.append(track)
         }
 
-        var index: Int = 0;
+        var index: Int = 0
         if (trackIndex.intValue > player.items.count) {
             reject("index_out_of_bounds", "The track index is out of bounds", nil)
         } else if trackIndex.intValue == -1 { // -1 means no index was passed and therefore should be inserted at the end.


### PR DESCRIPTION
Important to note, I only tested this on the react-native-track-player example with a few items and setting the index. Looks like it worked ok but it's not a great substitute for a proper test. I probably should write a test to ensure both android and ios are returning the expected index but I'd like to continue my project for now.
