### PR TITLE
Fix Android startup crash

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -416,7 +416,9 @@ class MusicService : HeadlessJsTaskService() {
 
     override fun onDestroy() {
         handler.post {
-            player.destroy()
+            if (this::player.isInitialized) {
+                player.destroy()
+            }
             handler.removeMessages(0)
         }
 


### PR DESCRIPTION
Aims to resolve:
```
kotlin.UninitializedPropertyAccessException: 
  at com.doublesymmetry.trackplayer.service.MusicService.onDestroy$lambda-39 (MusicService.kt:419)
  at com.doublesymmetry.trackplayer.service.MusicService.$r8$lambda$yHrK6Kb_ZEk8luZaR5-cjKXX7cQ (MusicService.kt)
  at com.doublesymmetry.trackplayer.service.MusicService$$InternalSyntheticLambda$0$f7db617717936a6c1dcadf6ab22f7407448e9581b0bc4dcf89b6c40dd127d014$0.run (MusicService.java:2)
  at android.os.Handler.handleCallback (Handler.java:883)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loop (Looper.java:237)
  at android.app.ActivityThread.main (ActivityThread.java:7762)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1047)
```

See: https://github.com/DoubleSymmetry/react-native-track-player/discussions/1264#discussioncomment-2228852