### PR TITLE
Feat/seek initial time

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -375,25 +375,40 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     }
 
     @ReactMethod
-    fun skip(index: Int, callback: Promise) {
+    fun skip(index: Int, initialTime: Float, callback: Promise) {
         if (verifyServiceBoundOrReject(callback)) return
 
         musicService.skip(index)
+
+        if (initialTime >= 0) {
+            musicService.seekTo(initialTime)
+        }
+
         callback.resolve(null)
     }
 
     @ReactMethod
-    fun skipToNext(callback: Promise) {
+    fun skipToNext(initialTime: Float, callback: Promise) {
         if (verifyServiceBoundOrReject(callback)) return
         musicService.skipToNext()
+
+        if (initialTime >= 0) {
+            musicService.seekTo(initialTime)
+        }
+
         callback.resolve(null)
     }
 
     @ReactMethod
-    fun skipToPrevious(callback: Promise) {
+    fun skipToPrevious(initialTime: Float, callback: Promise) {
         if (verifyServiceBoundOrReject(callback)) return
 
         musicService.skipToPrevious()
+
+        if (initialTime >= 0) {
+            musicService.seekTo(initialTime)
+        }
+
         callback.resolve(null)
     }
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -173,7 +173,7 @@ Removes one or more tracks from the queue.
 | ------ | -------- | ------------- |
 | tracks | `array` of track indexes or a single one | The tracks that will be removed |
 
-#### `skip(index)`
+#### `skip(index, initialTime)`
 Skips to a track in the queue.
 
 **Returns:** `Promise`
@@ -181,16 +181,26 @@ Skips to a track in the queue.
 | Param  | Type     | Description     |
 | ------ | -------- | --------------- |
 | index  | `number` | The track index |
+| initialTime | `number` | **Optional.** Sets the initial playback for the track you're skipping to. |
 
-#### `skipToNext()`
+#### `skipToNext(initialTime)`
 Skips to the next track in the queue.
 
 **Returns:** `Promise`
 
-#### `skipToPrevious()`
+| Param  | Type     | Description     |
+| ------ | -------- | --------------- |
+| initialTime | `number` | **Optional.** Sets the initial playback for the track you're skipping to. |
+
+#### `skipToPrevious(initialTime)`
 Skips to the previous track in the queue.
 
 **Returns:** `Promise`
+
+| Param  | Type     | Description     |
+| ------ | -------- | --------------- |
+| initialTime | `number` | **Optional.** Sets the initial playback for the track you're skipping to. |
+
 
 #### `reset()`
 Resets the player stopping the current track and clearing the queue.

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -299,7 +299,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             reject("player_not_initialized", "The player is not initialized. Call setupPlayer first.", nil)
             return
         }
-        
+
         print("Destroying player")
         self.player.stop()
         self.player.nowPlayingInfoController.clear()
@@ -362,7 +362,7 @@ public class RNTrackPlayer: RCTEventEmitter {
             index = trackIndex.intValue
             try? player.add(items: tracks, at: trackIndex.intValue)
         }
-        
+
         resolve(index)
     }
 
@@ -393,8 +393,13 @@ public class RNTrackPlayer: RCTEventEmitter {
         resolve(NSNull())
     }
 
-    @objc(skip:resolver:rejecter:)
-    public func skip(to trackIndex: NSNumber, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    @objc(skip:initialTime:resolver:rejecter:)
+    public func skip(
+        to trackIndex: NSNumber,
+        initialTime: Double,
+        resolve: RCTPromiseResolveBlock,
+        reject: RCTPromiseRejectBlock
+    ) {
         if !hasInitialized {
             reject("player_not_initialized", "The player is not initialized. Call setupPlayer first.", nil)
             return
@@ -407,11 +412,21 @@ public class RNTrackPlayer: RCTEventEmitter {
 
         print("Skipping to track:", trackIndex)
         try? player.jumpToItem(atIndex: trackIndex.intValue, playWhenReady: player.playerState == .playing)
-        resolve(NSNull())
+
+        // if an initialTime is passed the seek to it
+        if (initialTime >= 0) {
+            self.seek(to: initialTime, resolve: resolve, reject: reject)
+        } else {
+            resolve(NSNull())
+        }
     }
 
-    @objc(skipToNext:rejecter:)
-    public func skipToNext(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    @objc(skipToNext:resolver:rejecter:)
+    public func skipToNext(
+        initialTime: Double,
+        resolve: RCTPromiseResolveBlock,
+        reject: RCTPromiseRejectBlock
+    ) {
         if !hasInitialized {
             reject("player_not_initialized", "The player is not initialized. Call setupPlayer first.", nil)
             return
@@ -419,14 +434,24 @@ public class RNTrackPlayer: RCTEventEmitter {
 
         do {
             try player.next()
-            resolve(NSNull())
+
+            // if an initialTime is passed the seek to it
+            if (initialTime >= 0) {
+                self.seek(to: initialTime, resolve: resolve, reject: reject)
+            } else {
+                resolve(NSNull())
+            }
         } catch (_) {
             reject("queue_exhausted", "There is no tracks left to play", nil)
         }
     }
 
-    @objc(skipToPrevious:rejecter:)
-    public func skipToPrevious(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    @objc(skipToPrevious:resolver:rejecter:)
+    public func skipToPrevious(
+        initialTime: Double,
+        resolve: RCTPromiseResolveBlock,
+        reject: RCTPromiseRejectBlock
+    ) {
         if !hasInitialized {
             reject("player_not_initialized", "The player is not initialized. Call setupPlayer first.", nil)
             return
@@ -434,7 +459,13 @@ public class RNTrackPlayer: RCTEventEmitter {
 
         do {
             try player.previous()
-            resolve(NSNull())
+
+            // if an initialTime is passed the seek to it
+            if (initialTime >= 0) {
+                self.seek(to: initialTime, resolve: resolve, reject: reject)
+            } else {
+                resolve(NSNull())
+            }
         } catch (_) {
             reject("no_previous_track", "There is no previous track", nil)
         }

--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.m
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.m
@@ -38,13 +38,16 @@ RCT_EXTERN_METHOD(removeUpcomingTracks:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(skip:(nonnull NSNumber *)trackIndex
+                  initialTime:(double)initialTime
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(skipToNext:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(skipToNext:(double)initialTime
+                  resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(skipToPrevious:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(skipToPrevious:(double)initialTime
+                  resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(reset:(RCTPromiseResolveBlock)resolve

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -22,6 +22,15 @@ function resolveImportedPath(path?: number | string) {
   return resolveAssetSource(path) || path
 }
 
+// RN doesn't allow nullable NSNumbers so convert optional number parameters
+// to a conventional default.
+function optionalNumberToDefault(
+  num?: number,
+  defaultValue: number = -1,
+): number {
+  return num === undefined ? defaultValue : num;
+}
+
 // MARK: - General API
 
 /**
@@ -90,7 +99,7 @@ async function add(tracks: Track | Track[], insertBeforeIndex?: number): Promise
   }
 
   // Note: we must be careful about passing nulls to non nullable parameters on Android.
-  return TrackPlayer.add(tracks, insertBeforeIndex === undefined ? -1 : insertBeforeIndex)
+  return TrackPlayer.add(tracks, optionalNumberToDefault(insertBeforeIndex))
 }
 
 /**
@@ -114,22 +123,22 @@ async function removeUpcomingTracks(): Promise<void> {
 /**
  * Skips to a track in the queue.
  */
-async function skip(trackIndex: number): Promise<void> {
-  return TrackPlayer.skip(trackIndex)
+async function skip(trackIndex: number, initialPosition?: number): Promise<void> {
+  return TrackPlayer.skip(trackIndex, optionalNumberToDefault(initialPosition))
 }
 
 /**
  * Skips to the next track in the queue.
  */
-async function skipToNext(): Promise<void> {
-  return TrackPlayer.skipToNext()
+async function skipToNext(initialPosition?: number): Promise<void> {
+  return TrackPlayer.skipToNext(optionalNumberToDefault(initialPosition))
 }
 
 /**
  * Skips to the previous track in the queue.
  */
-async function skipToPrevious(): Promise<void> {
-  return TrackPlayer.skipToPrevious()
+async function skipToPrevious(initialPosition?: number): Promise<void> {
+  return TrackPlayer.skipToPrevious(optionalNumberToDefault(initialPosition))
 }
 
 // MARK: - Control Center / Notifications API

--- a/windows/RNTrackPlayer/RNTrackPlayer.cpp
+++ b/windows/RNTrackPlayer/RNTrackPlayer.cpp
@@ -51,7 +51,7 @@ void TrackPlayerModule::Destroy() noexcept
 {
     if (!manager)
         return;
-    
+
     manager->SwitchPlayback(nullptr);
 }
 
@@ -166,31 +166,43 @@ void TrackPlayerModule::Remove(JSValueArray arr, ReactPromise<JSValue> promise) 
     player->Remove(tracks, promise);
 }
 
-void TrackPlayerModule::Skip(const int trackId, ReactPromise<JSValue> promise) noexcept
+void TrackPlayerModule::Skip(const int trackId, double initialTime, ReactPromise<JSValue> promise) noexcept
 {
     auto player = manager ? manager->GetPlayer() : nullptr;
     if (Utils::CheckPlayback(player, promise))
         return;
 
     player->Skip(trackId, promise);
+
+    if (initialTime > 0) {
+        player->SeekTo(initialTime);
+    }
 }
 
-void TrackPlayerModule::SkipToNext(ReactPromise<JSValue> promise) noexcept
+void TrackPlayerModule::SkipToNext(double initialTime, ReactPromise<JSValue> promise) noexcept
 {
     auto player = manager ? manager->GetPlayer() : nullptr;
     if (Utils::CheckPlayback(player, promise))
         return;
 
     player->SkipToNext(promise);
+
+    if (initialTime > 0) {
+        player->SeekTo(initialTime);
+    }
 }
 
-void TrackPlayerModule::SkipToPrevious(ReactPromise<JSValue> promise) noexcept
+void TrackPlayerModule::SkipToPrevious(double initialTime, ReactPromise<JSValue> promise) noexcept
 {
     auto player = manager ? manager->GetPlayer() : nullptr;
     if (Utils::CheckPlayback(player, promise))
         return;
 
     player->SkipToPrevious(promise);
+
+    if (initialTime > 0) {
+        player->SeekTo(initialTime);
+    }
 }
 
 void TrackPlayerModule::GetQueue(ReactPromise<JSValue> promise) noexcept
@@ -224,7 +236,7 @@ void TrackPlayerModule::GetCurrentTrack(ReactPromise<JSValue> promise) noexcept
         promise.Resolve(index);
     } else {
         promise.Resolve(nullptr);
-    } 
+    }
 }
 
 void TrackPlayerModule::GetTrack(const int index, ReactPromise<JSValue> promise) noexcept

--- a/windows/RNTrackPlayer/RNTrackPlayer.h
+++ b/windows/RNTrackPlayer/RNTrackPlayer.h
@@ -55,13 +55,13 @@ namespace winrt::RNTrackPlayer {
     void Remove(JSValueArray arr, ReactPromise<JSValue> promise) noexcept;
 
     REACT_METHOD(Skip, L"skip")
-    void Skip(const int trackId, ReactPromise<JSValue> promise) noexcept;
+    void Skip(const int trackId, double initialTime, ReactPromise<JSValue> promise) noexcept;
 
     REACT_METHOD(SkipToNext, L"skipToNext")
-    void SkipToNext(ReactPromise<JSValue> promise) noexcept;
+    void SkipToNext(double initialTime, ReactPromise<JSValue> promise) noexcept;
 
     REACT_METHOD(SkipToPrevious, L"skipToPrevious")
-    void SkipToPrevious(ReactPromise<JSValue> promise) noexcept;
+    void SkipToPrevious(double initialTime, ReactPromise<JSValue> promise) noexcept;
 
     REACT_METHOD(GetQueue, L"getQueue")
     void GetQueue(ReactPromise<JSValue> promise) noexcept;


### PR DESCRIPTION
Based on the [conversation and decisions made on this PR](https://github.com/DoubleSymmetry/react-native-track-player/pull/713#issuecomment-1036286082). This PR implements the following interface:

```ts
interface TrackPlayer {
  public async skipToNext(initialTime?: number);
  public async skipToPrevious(initialTime?: number);
  public async skip(index: number, initialTime?: number);
}
```