### PR TITLE
Don't round times to integer

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -224,7 +224,7 @@ class MusicService : HeadlessJsTaskService() {
     }
 
     fun seekTo(seconds: Float) {
-        handler.post { player.seek(seconds.toLong(), TimeUnit.SECONDS) }
+        handler.post { player.seek((seconds * 1000).toLong(), TimeUnit.MILLISECONDS) }
     }
 
     fun getCurrentTrackIndex(callback: (Int) -> Unit) {

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -212,7 +212,7 @@ class MusicService : HeadlessJsTaskService() {
     }
 
     fun skip(index: Int) {
-        handler.post { player.jumpToItem(index) }
+        handler.post { player.jumpToItem(index, player.isPlaying) }
     }
 
     fun skipToNext() {

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -271,19 +271,19 @@ class MusicService : HeadlessJsTaskService() {
 
     fun getDurationInSeconds(callback: (Double) -> Unit) {
         handler.post {
-            callback(TimeUnit.MILLISECONDS.toSeconds(player.duration).toDouble())
+            callback(player.duration.toDouble() / 1000)
         }
     }
 
     fun getPositionInSeconds(callback: (Double) -> Unit) {
         handler.post {
-            callback(TimeUnit.MILLISECONDS.toSeconds(player.position).toDouble())
+            callback(player.position.toDouble() / 1000)
         }
     }
 
     fun getBufferedPositionInSeconds(callback: (Double) -> Unit) {
         handler.post {
-            callback(TimeUnit.MILLISECONDS.toSeconds(player.bufferedPosition).toDouble())
+            callback(player.bufferedPosition.toDouble() / 1000)
         }
     }
 


### PR DESCRIPTION
We need to get the accurate position, not just integers. And I don't see any reason to round it to ints.