### PR TITLE
Fix iOS track loop crash

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -635,10 +635,8 @@ public class RNTrackPlayer: RCTEventEmitter {
         }
 
         // fire an event for the same track starting again
-        switch player.repeatMode {
-        case .track:
+        if player.items.count != 0 && player.repeatMode == .track {
             handleAudioPlayerQueueIndexChange(previousIndex: player.currentIndex, nextIndex: player.currentIndex)
-        default: break
         }
     }
 


### PR DESCRIPTION
Currently on iOS, reaching the end of the queue with repeat mode set to `track` causes the app to crash. This bug has two manifestations as long as the repeat mode is `track`:
1. When playing a queue with only 1 track, the app crashes as soon as it reaches the end of the track
2. When playing a queue with more than 1 track, the app will successfully loop the first track, but if you try to clean up at some point using `TrackPlayer.reset`, the app will crash

I don't know if there is another flow or edge case I'm unaware of or a better solution to this problem, but my proposed solution does successfully allow the track to loop correctly in both circumstances without the app crashing.