### PR TITLE
feat(android): move the jcenter dependency into the android library t…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,11 @@ repositories {
 
     mavenCentral()
     google()
+
+    // FIXME: this can be removed once exoplayer has been migrated to a maven
+    // release. See more details here:
+    // https://github.com/DoubleSymmetry/react-native-track-player/issues/1235#issuecomment-921266932
+    jcenter()
 }
 
 dependencies {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -34,7 +34,6 @@ allprojects {
         }
 
         google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
…o prevent installation issues

https://github.com/DoubleSymmetry/react-native-track-player/issues/1235#issuecomment-921266932