### PR TITLE
[iOS] Streaming Updates

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -129,8 +129,9 @@ If the player is already initialized, the promise will resolve instantly.
 | options.backBuffer   | `number` | Time in seconds that should be kept in the buffer behind the current playhead time. | 0 | ✓ | ✗ | ✗ |
 | options.maxCacheSize | `number` | Maximum cache size in kilobytes | 0 | ✓ | ✗ | ✗ |
 | options.iosCategory  | `IOSCategory` | [AVAudioSession.Category](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616615-category) for iOS. Sets on `play()` | `playback` | ✗ | ✓ | ✗ |
-| options.iosCategoryOptions | `IOSCategoryOptions[]` | [AVAudioSession.CategoryOptions](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616503-categoryoptions) for iOS. Sets on `play()` | `[]` | ✗ | ✓ | ✗ |
 | options.iosCategoryMode  | `IOSCategoryMode` | [AVAudioSession.Mode](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616508-mode) for iOS. Sets on `play()` | `default` | ✗ | ✓ | ✗ |
+| options.iosCategoryPolicy  | `IOSCategoryPolicy` | [AVAudioSession.Policy](https://developer.apple.com/documentation/avfaudio/avaudiosession/2887118-routesharingpolicy) for iOS. Sets on `play()` | `default` | ✗ | ✓ | ✗ |
+| options.iosCategoryOptions | `IOSCategoryOptions[]` | [AVAudioSession.CategoryOptions](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616503-categoryoptions) for iOS. Sets on `play()` | `[]` | ✗ | ✓ | ✗ |
 | options.waitForBuffer   | `boolean` | Indicates whether the player should automatically delay playback in order to minimize stalling. If you notice that network media immediately pauses after it buffers, setting this to `true` may help. | false | ✗ | ✓ | ✗ |
 | options.autoUpdateMetadata   | `boolean` | Indicates whether the player should automatically update now playing metadata data in control center / notification. | true | ✓ | ✗ | ✗ |
 

--- a/ios/RNTrackPlayer/Models/SessionCategories.swift
+++ b/ios/RNTrackPlayer/Models/SessionCategories.swift
@@ -10,8 +10,7 @@ import Foundation
 import MediaPlayer
 import AVFoundation
 
-enum SessionCategory : String {
-    
+enum SessionCategory: String {
     case playAndRecord, multiRoute, playback, ambient, soloAmbient
     
     func mapConfigToAVAudioSessionCategory() -> AVAudioSession.Category {
@@ -30,32 +29,28 @@ enum SessionCategory : String {
     }
 }
 
-enum SessionCategoryOptions : String {
+enum SessionCategoryPolicy: String {
+    case `default`, longFormAudio, independent, longFormVideo
     
-    case mixWithOthers, duckOthers, interruptSpokenAudioAndMixWithOthers, allowBluetooth, allowBluetoothA2DP, allowAirPlay, defaultToSpeaker
-
-    func mapConfigToAVAudioSessionCategoryOptions() -> AVAudioSession.CategoryOptions? {
+    func mapConfigToAVAudioSessionCategoryPolicy() -> AVAudioSession.RouteSharingPolicy {
         switch self {
-        case .mixWithOthers:
-            return .mixWithOthers
-        case .duckOthers:
-            return .duckOthers
-        case .interruptSpokenAudioAndMixWithOthers:
-            return .interruptSpokenAudioAndMixWithOthers
-        case .allowBluetooth:
-            return .allowBluetooth
-        case .allowBluetoothA2DP:
-            return .allowBluetoothA2DP
-        case .allowAirPlay:
-            return .allowAirPlay
-        case .defaultToSpeaker:
-            return .defaultToSpeaker
+        case .default:
+            return .default
+        case .longFormAudio:
+            return .longFormAudio
+        case .independent:
+            return .independent
+        case .longFormVideo:
+            if #available(iOS 13.0, *) {
+                return .longFormVideo
+            } else {
+                return .longFormAudio
+            }
         }
     }
 }
 
-enum SessionCategoryMode : String {
-    
+enum SessionCategoryMode: String {
     case `default`, gameChat, measurement, moviePlayback, spokenAudio, videoChat, videoRecording, voiceChat, voicePrompt
     
     func mapConfigToAVAudioSessionCategoryMode() -> AVAudioSession.Mode {
@@ -87,3 +82,25 @@ enum SessionCategoryMode : String {
     }
 }
 
+enum SessionCategoryOptions : String {
+    case mixWithOthers, duckOthers, interruptSpokenAudioAndMixWithOthers, allowBluetooth, allowBluetoothA2DP, allowAirPlay, defaultToSpeaker
+    
+    func mapConfigToAVAudioSessionCategoryOptions() -> AVAudioSession.CategoryOptions? {
+        switch self {
+        case .mixWithOthers:
+            return .mixWithOthers
+        case .duckOthers:
+            return .duckOthers
+        case .interruptSpokenAudioAndMixWithOthers:
+            return .interruptSpokenAudioAndMixWithOthers
+        case .allowBluetooth:
+            return .allowBluetooth
+        case .allowBluetoothA2DP:
+            return .allowBluetoothA2DP
+        case .allowAirPlay:
+            return .allowAirPlay
+        case .defaultToSpeaker:
+            return .defaultToSpeaker
+        }
+    }
+}

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -11,18 +11,20 @@ import MediaPlayer
 import SwiftAudioEx
 
 @objc(RNTrackPlayer)
-public class RNTrackPlayer: RCTEventEmitter {
+public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
 
     // MARK: - Attributes
 
     private var hasInitialized = false
     private let player = QueuedAudioPlayer()
+    private let audioSessionController = AudioSessionController.shared
 
     // MARK: - Lifecycle Methods
 
     public override init() {
         super.init()
 
+        audioSessionController.delegate = self
         player.event.playbackEnd.addListener(self, handleAudioPlayerPlaybackEnded)
         player.event.receiveMetadata.addListener(self, handleAudioPlayerMetadataReceived)
         player.event.stateChange.addListener(self, handleAudioPlayerStateChange)
@@ -106,35 +108,18 @@ public class RNTrackPlayer: RCTEventEmitter {
             "remote-bookmark",
         ]
     }
-
-    func setupInterruptionHandling() {
-        let notificationCenter = NotificationCenter.default
-        notificationCenter.removeObserver(self)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(handleInterruption),
-                                       name: AVAudioSession.interruptionNotification,
-                                       object: nil)
-    }
-
-    @objc func handleInterruption(notification: Notification) {
-        guard let userInfo = notification.userInfo,
-              let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
-            return
-        }
-        if type == .began {
+    
+    // MARK: - AudioSessionControllerDelegate
+    
+    public func handleInterruption(type: InterruptionType) {
+        switch type {
+        case .began:
             // Interruption began, take appropriate actions (save state, update user interface)
             self.sendEvent(withName: "remote-duck", body: [
                 "paused": true
             ])
-        }
-        else if type == .ended {
-            guard let optionsValue =
-                    userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
-                return
-            }
-            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-            if options.contains(.shouldResume) {
+        case let .ended(shouldResume):
+            if shouldResume {
                 // Interruption Ended - playback should resume
                 self.sendEvent(withName: "remote-duck", body: [
                     "paused": false
@@ -158,8 +143,6 @@ public class RNTrackPlayer: RCTEventEmitter {
             return
         }
 
-        setupInterruptionHandling();
-
         // configure if player waits to play
         let autoWait: Bool = config["waitForBuffer"] as? Bool ?? false
         player.automaticallyWaitsToMinimizeStalling = autoWait
@@ -174,8 +157,9 @@ public class RNTrackPlayer: RCTEventEmitter {
 
         // configure audio session - category, options & mode
         var sessionCategory: AVAudioSession.Category = .playback
-        var sessionCategoryOptions: AVAudioSession.CategoryOptions = []
         var sessionCategoryMode: AVAudioSession.Mode = .default
+        var sessionCategoryPolicy: AVAudioSession.RouteSharingPolicy = .default
+        var sessionCategoryOptions: AVAudioSession.CategoryOptions = []
 
         if
             let sessionCategoryStr = config["iosCategory"] as? String,
@@ -183,22 +167,26 @@ public class RNTrackPlayer: RCTEventEmitter {
             sessionCategory = mappedCategory.mapConfigToAVAudioSessionCategory()
         }
 
-        let sessionCategoryOptsStr = config["iosCategoryOptions"] as? [String]
-        let mappedCategoryOpts = sessionCategoryOptsStr?.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() } ?? []
-        sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
-
         if
             let sessionCategoryModeStr = config["iosCategoryMode"] as? String,
             let mappedCategoryMode = SessionCategoryMode(rawValue: sessionCategoryModeStr) {
             sessionCategoryMode = mappedCategoryMode.mapConfigToAVAudioSessionCategoryMode()
         }
+        
+        if
+            let sessionCategoryPolicyStr = config["iosCategoryPolicy"] as? String,
+            let mappedCategoryPolicy = SessionCategoryPolicy(rawValue: sessionCategoryPolicyStr) {
+            sessionCategoryPolicy = mappedCategoryPolicy.mapConfigToAVAudioSessionCategoryPolicy()
+        }
+        
+        let sessionCategoryOptsStr = config["iosCategoryOptions"] as? [String]
+        let mappedCategoryOpts = sessionCategoryOptsStr?.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() } ?? []
+        sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
 
-        // Progressively opt into AVAudioSession policies for background audio
-        // and AirPlay 2.
         if #available(iOS 13.0, *) {
-            try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, policy: sessionCategory == .ambient ? .default : .longFormAudio, options: sessionCategoryOptions)
+            try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, policy: sessionCategoryPolicy, options: sessionCategoryOptions)
         } else if #available(iOS 11.0, *) {
-            try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, policy: sessionCategory == .ambient ? .default : .longForm, options: sessionCategoryOptions)
+            try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, policy: sessionCategoryPolicy, options: sessionCategoryOptions)
         } else {
             try? AVAudioSession.sharedInstance().setCategory(sessionCategory, mode: sessionCategoryMode, options: sessionCategoryOptions)
         }

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -713,7 +713,11 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         sendEvent(withName: "playback-state", body: ["state": State.fromPlayerState(state: state).rawValue])
     }
 
-    func handleAudioPlayerMetadataReceived(metadata: [AVMetadataItem]) {
+    func handleAudioPlayerMetadataReceived(metadata: [AVTimedMetadataGroup]) {
+        // SwiftAudioEx was updated to return the array of timed metadata
+        // Until we have support for that in RNTP, we take the first item to keep existing behaviour.
+        let metadata = metadata.first?.items ?? []
+        
         func getMetadataItem(forIdentifier: AVMetadataIdentifier) -> String {
             return AVMetadataItem.metadataItems(from: metadata, filteredByIdentifier: forIdentifier).first?.stringValue ?? ""
         }

--- a/react-native-track-player.podspec
+++ b/react-native-track-player.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.swift_version = "4.2"
 
   s.dependency "React-Core"
-  s.dependency "SwiftAudioEx", "0.14.7"
+  s.dependency "SwiftAudioEx", "0.15.0"
 end


### PR DESCRIPTION
This PR has a few updates on the iOS side:
- Introduces a new configuration option: `iosCategoryPolicy` and defaults to `default` for better Airplay support
- Updates to latest SwiftAudioEx:
  - Uses new interruption delegate
  - Uses new metadata observer which supports chapters (but not used yet in RNTP)