### PR TITLE
Warn about potential crash in "Getting Started"

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -10,15 +10,7 @@ redirect_from:
 # Getting Started
 
 ## Starting off
-First of all, you need to set up the player. This usually takes less than a second:
-```typescript
-import TrackPlayer from 'react-native-track-player';
-
-await TrackPlayer.setupPlayer({})
-// The player is ready to be used
-```
-
-You also need to register a [playback service](#playback-service) right after registering the main component of your app:
+First, you need to register a [playback service](#playback-service) right after registering the main component of your app (typically in your `index.js` file at the root of your project):
 ```typescript
 // AppRegistry.registerComponent(...);
 TrackPlayer.registerPlaybackService(() => require('./service'));
@@ -31,6 +23,16 @@ module.exports = async function() {
     // but it will be used later in the "Receiving Events" section
 }
 ```
+
+Then, you need to set up the player. This usually takes less than a second:
+```typescript
+import TrackPlayer from 'react-native-track-player';
+
+await TrackPlayer.setupPlayer()
+// The player is ready to be used
+```
+
+Make sure the setup method has completed before interacting with any other functions in `TrackPlayer` in order to avoid instability.
 
 ## Controlling the Player
 


### PR DESCRIPTION
I encountered a crash recently in the latest `v2.2.0-rc3` related to calling a method on `TrackPlayer` before setup was complete and thought it should maybe be documented more clearly.  The details are in #1475 but the gist is I had a race condition between calling `getQueue` and `setupPlayer`, and that didn't used to crash the app but now it does and that seems to be intentional.

Not super sure on the wording here, but I thought it would make sense to flip the order of what's "first" since you always want to register the playback service, and then calling `setupPlayer` comes later.