### PR TITLE
docs(config): prepare to release the current docs as "next"

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -26,13 +26,6 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/doublesymmetry/react-native-track-player/tree/main/docs/',
-          lastVersion: 'current',
-          versions: {
-            current: {
-              label: '2.2',
-              path: '2.2',
-            },
-          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
@dcvz this will result in two docs versions: `2.1` & `next`. Next will ship with a warning that it's unreleased.