### PR TITLE
fix(ios, track): fix issues with the setting & unsetting of track …

### DIFF
--- a/ios/RNTrackPlayer/Models/Track.swift
+++ b/ios/RNTrackPlayer/Models/Track.swift
@@ -105,14 +105,14 @@ class Track: NSObject, AudioItem, TimePitching, AssetOptionsProviding {
                 URLSession.shared.dataTask(with: artworkURL, completionHandler: { (data, _, error) in
                     if let data = data, let artwork = UIImage(data: data), error == nil {
                         handler(artwork)
+                    } else {
+                        handler(nil)
                     }
-
-                    handler(nil)
                 }).resume()
             }
+        } else {
+            handler(nil)
         }
-
-        handler(nil)
     }
 
     // MARK: - TimePitching Protocol

--- a/ios/RNTrackPlayer/Utils/Metadata.swift
+++ b/ios/RNTrackPlayer/Utils/Metadata.swift
@@ -54,6 +54,8 @@ struct Metadata {
             })
             
             currentImageTask?.resume()
+        } else {
+            player.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(nil))
         }
     }
 }


### PR DESCRIPTION
…artwork

allow for the setting of empty artwork, use else conditions in Track.getArtwork to prevent multiple
callbacks from firing

https://github.com/doublesymmetry/react-native-track-player/issues/1511