### PR TITLE
fix(android): fix an issue causing a crash on android during a getRep…

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -512,7 +512,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     fun getRepeatMode(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
 
-        callback.resolve(musicService.getRepeatMode())
+        callback.resolve(musicService.getRepeatMode().ordinal)
     }
 
     @ReactMethod


### PR DESCRIPTION
…eatMode call

this issue was introduced here
https://github.com/doublesymmetry/react-native-track-player/commit/9c1337283d940d0ef1a0103a7c2672ce058e0838#diff-a81d1f66559c798bf4f60418b12aafb4df6004119496833a1ad6c72f15693e06L500

https://github.com/doublesymmetry/react-native-track-player/issues/1578