### PR TITLE
fix(ios): fix an issue with `reset()` causing a crash on iOS due to o…

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -821,7 +821,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
 
         // Load isLiveStream option for track
         var isTrackLiveStream = false
-        if let nextIndex = nextIndex {
+        if let nextIndex = nextIndex, nextIndex < player.items.count {
             let track = player.items[nextIndex]
             isTrackLiveStream = (track as? Track)?.isLiveStream ?? false
         }


### PR DESCRIPTION
…ut of range exception

https://github.com/doublesymmetry/react-native-track-player/issues/1585