### PR TITLE
feat: type support for event listener

### DIFF
--- a/example/src/services/PlaybackService.ts
+++ b/example/src/services/PlaybackService.ts
@@ -1,26 +1,28 @@
 import TrackPlayer, {Event, State} from 'react-native-track-player';
-import type {ProgressUpdateEvent} from 'react-native-track-player';
 
 let wasPausedByDuck = false;
 
 export async function PlaybackService() {
-  TrackPlayer.addEventListener(Event.RemotePause, () => {
+  TrackPlayer.addEventListener<Event.RemotePause>(Event.RemotePause, () => {
     TrackPlayer.pause();
   });
 
-  TrackPlayer.addEventListener(Event.RemotePlay, () => {
+  TrackPlayer.addEventListener<Event.RemotePlay>(Event.RemotePlay, () => {
     TrackPlayer.play();
   });
 
-  TrackPlayer.addEventListener(Event.RemoteNext, () => {
+  TrackPlayer.addEventListener<Event.RemoteNext>(Event.RemoteNext, () => {
     TrackPlayer.skipToNext();
   });
 
-  TrackPlayer.addEventListener(Event.RemotePrevious, () => {
-    TrackPlayer.skipToPrevious();
-  });
+  TrackPlayer.addEventListener<Event.RemotePrevious>(
+    Event.RemotePrevious,
+    () => {
+      TrackPlayer.skipToPrevious();
+    },
+  );
 
-  TrackPlayer.addEventListener(Event.RemoteDuck, async e => {
+  TrackPlayer.addEventListener<Event.RemoteDuck>(Event.RemoteDuck, async e => {
     if (e.permanent === true) {
       TrackPlayer.stop();
     } else {
@@ -37,18 +39,24 @@ export async function PlaybackService() {
     }
   });
 
-  TrackPlayer.addEventListener(Event.PlaybackQueueEnded, data => {
-    console.log('Event.PlaybackQueueEnded', data);
-  });
+  TrackPlayer.addEventListener<Event.PlaybackQueueEnded>(
+    Event.PlaybackQueueEnded,
+    data => {
+      console.log('Event.PlaybackQueueEnded', data);
+    },
+  );
 
-  TrackPlayer.addEventListener(Event.PlaybackTrackChanged, data => {
-    console.log('Event.PlaybackTrackChanged', data);
-  });
+  TrackPlayer.addEventListener<Event.PlaybackTrackChanged>(
+    Event.PlaybackTrackChanged,
+    data => {
+      console.log('Event.PlaybackTrackChanged', data);
+    },
+  );
 
-  TrackPlayer.addEventListener(
+  TrackPlayer.addEventListener<Event.PlaybackProgressUpdated>(
     Event.PlaybackProgressUpdated,
-    (data: ProgressUpdateEvent) => {
+    data => {
       console.log('Event.PlaybackProgressUpdated', data);
     },
   );
-};
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -30,7 +30,7 @@ export const usePlaybackState = () => {
     // Set initial state
     setPlayerState()
 
-    const sub = TrackPlayer.addEventListener(Event.PlaybackState, data => {
+    const sub = TrackPlayer.addEventListener<Event.PlaybackState>(Event.PlaybackState, data => {
       setState(data.state)
     })
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -172,6 +172,79 @@ export enum Event {
   RemoteBookmark = 'remote-bookmark',
 }
 
+export interface EventListenerProp {
+  [Event.PlaybackState]: {
+    state: State
+  }
+  [Event.PlaybackError]: {
+    code: string
+    message: string
+  }
+  [Event.PlaybackQueueEnded]: {
+    track: number
+    position: number
+  }
+  [Event.PlaybackTrackChanged]: {
+    track: number
+    position: number
+    nextTrack: number
+  }
+  [Event.PlaybackMetadataReceived]: {
+    source: string
+    title: string | null
+    url: string | null
+    artist: string | null
+    album: string | null
+    date: string | null
+    genre: string | null
+  }
+  [Event.PlaybackProgressUpdated]: {
+    position: number
+    duration: number
+    buffer: number
+    track: number
+  }
+  [Event.RemotePlay]: null
+  [Event.RemotePlayId]: {
+    id: string
+  }
+  [Event.RemotePlaySearch]: {
+    query: string
+    focus: string
+    title: string
+    artist: string
+    album: string
+    date: string
+    playlist: string
+  }
+  [Event.RemotePause]: null
+  [Event.RemoteStop]: null
+  [Event.RemoteSkip]: {
+    index: number
+  }
+  [Event.RemoteNext]: null
+  [Event.RemotePrevious]: null
+  [Event.RemoteJumpForward]: {
+    interval: number
+  }
+  [Event.RemoteJumpBackward]: {
+    interval: number
+  }
+  [Event.RemoteSeek]: {
+    position: number
+  }
+  [Event.RemoteSetRating]: {
+    rating: boolean | number
+  }
+  [Event.RemoteDuck]: {
+    paused: boolean
+    permanent: boolean
+  }
+  [Event.RemoteLike]: null
+  [Event.RemoteDislike]: null
+  [Event.RemoteBookmark]: null
+}
+
 export enum TrackType {
   Default = 'default',
   Dash = 'dash',

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -10,6 +10,7 @@ import {
   TrackMetadataBase,
   NowPlayingMetadata,
   RepeatMode,
+  EventListenerProp,
 } from './interfaces'
 
 const { TrackPlayerModule: TrackPlayer } = NativeModules
@@ -62,8 +63,8 @@ function registerPlaybackService(factory: () => ServiceHandler) {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function addEventListener(event: Event, listener: (data: any) => void) {
+type EventListener<T extends Event> = (data: EventListenerProp[T]) => void
+function addEventListener<T extends Event>(event: Event, listener: EventListener<T>) {
   return emitter.addListener(event, listener)
 }
 


### PR DESCRIPTION
I want event listener's parameter type, but that was `any`!
So
- Defined `interface EventListenerProp` 
- Added generics  to `function addEventListener` to enable type inference in listener function
  - This Generics receives `enum Event value`
  
 Now, listener's param is not any! (from example code)
<img width="631" alt="スクリーンショット 2022-07-10 19 00 41" src="https://user-images.githubusercontent.com/15419227/178140567-1d312e87-c7b5-4414-b4bc-162e97634a7b.png">

(Generics might be removed, but I don't figure out how to do it. :sob:)