### PR TITLE
chore: add CI task - check-typescript

### DIFF
--- a/.github/workflows/platform-validation.yml
+++ b/.github/workflows/platform-validation.yml
@@ -87,3 +87,22 @@ jobs:
         run: |-
           cd example/ios
           xcodebuild build -workspace example.xcworkspace -scheme example -destination 'platform=iOS Simulator,name=iPhone 12 Pro'
+  check-typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - name: Cache JS Dependencies
+        uses: c-hive/gha-yarn-cache@v1
+      - name: Install Yarn
+        run: npm install --global yarn
+      - name: Install Library Dependencies
+        run: yarn install
+      - name: Check Lint & Format
+        run: |
+          npm run lint:ci
+          npm run format:ci

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "prepublishOnly": "yarn lint",
     "preversion": "yarn lint",
     "version": "yarn format && git add -A src",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "lint:ci": "eslint \"src/**/*.ts\" --max-warnings=0",
+    "format:ci": "prettier --check \"src/**/*.ts\""
   },
   "files": [
     "lib/**/*",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -237,5 +237,5 @@ export interface ProgressState {
 }
 
 export interface ProgressUpdateEvent extends ProgressState {
-  track: number;
+  track: number
 }

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -24,11 +24,8 @@ function resolveImportedPath(path?: number | string) {
 
 // RN doesn't allow nullable NSNumbers so convert optional number parameters
 // to a conventional default.
-function optionalNumberToDefault(
-  num?: number,
-  defaultValue: number = -1,
-): number {
-  return num === undefined ? defaultValue : num;
+function optionalNumberToDefault(num?: number, defaultValue: number = -1): number {
+  return num === undefined ? defaultValue : num
 }
 
 // MARK: - General API


### PR DESCRIPTION
I found main branch has some format error in TypeScript code.
To prevent new error injection, I added a CI task that check TS code.

[Here](https://github.com/Spice-Z/react-native-track-player/pull/2), I confirmed CI task failed when TS code has error. 