### PR TITLE
ci(platform-validation-skip): add specific build jobs to platform-val…

### DIFF
--- a/.github/workflows/platform-validation-skip.yml
+++ b/.github/workflows/platform-validation-skip.yml
@@ -18,7 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-android:
+    runs-on: ubuntu-latest
+      steps:
+        - run: 'echo "No build required"'
+  build-ios:
+    runs-on: ubuntu-latest
+      steps:
+        - run: 'echo "No build required"'
+  check-typescript:
     runs-on: ubuntu-latest
       steps:
         - run: 'echo "No build required"'


### PR DESCRIPTION
…idation-skip

existing implementation still expects the build-ios and build-android jobs:
https://github.com/doublesymmetry/react-native-track-player/pull/1604