### PR TITLE
Provide an example for RemoteDuck behaviour

### DIFF
--- a/docs/docs/api/events.md
+++ b/docs/docs/api/events.md
@@ -169,3 +169,5 @@ On Android, the volume may also be lowered on an transient interruption without 
 | --------- | --------- | -------------------------------------------- |
 | paused    | `boolean` | On Android when `true` the player should pause playback, when `false` the player may resume playback. On iOS when `true` the playback was paused and when `false` the player may resume playback. |
 | permanent | `boolean` | Whether the interruption is permanent. On Android the player should stop playback.  |
+
+Implementation examples can be found in the [example project](https://github.com/doublesymmetry/react-native-track-player/blob/main/example/src/services/PlaybackService.ts).


### PR DESCRIPTION
Implementing a standard use-case that pauses when another app takes over wasn't obvious.

The check "was paused by duck" has to be handled in the callback, providing an example of working code that does this might help understand edge cases.

Our initial "naive" implementation was :
```js
  TrackPlayer.addEventListener(Event.RemoteDuck, (event) => {
    if (event.paused) {
      TrackPlayer.pause();
    } else {
      TrackPlayer.play();
    }
  });
```

However this would start playing the backgrounded track when the "ducked" state ends, regardless of the track being initially paused by human interaction or by the duck event.