### PR TITLE
Add a proper position to the AudioItemTransition event 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,8 +51,8 @@ repositories {
 }
 
 dependencies {
-     implementation "com.github.DoubleSymmetry:KotlinAudio:v0.1.34"
-//    implementation "com.github.doublesymmetry:kotlin-audio:0.1.36"
+    implementation 'com.github.DoubleSymmetry:KotlinAudio:v1.0'
+//    implementation "com.github.doublesymmetry:kotlin-audio:1.0"
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion getExtOrIntegerDefault('minSdkVersion') // RN's minimum version
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
 
-        versionCode 1
-        versionName '1.0'
+        versionCode 300
+        versionName '3.0'
 
         consumerProguardFiles 'proguard-rules.txt'
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-RNTP_kotlinVersion=1.5.31
+RNTP_kotlinVersion=1.7.10
 RNTP_minSdkVersion=21
 RNTP_targetSdkVersion=31
 RNTP_compileSdkVersion=31

--- a/android/src/main/java/com/doublesymmetry/trackplayer/extensions/NumberExt.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/extensions/NumberExt.kt
@@ -1,0 +1,13 @@
+package com.doublesymmetry.trackplayer.extensions
+
+class NumberExt {
+    companion object {
+        fun Number.toSeconds(): Double {
+            return this.toDouble() / 1000
+        }
+
+        fun Number.toMilliseconds(): Long {
+            return (this.toDouble() * 1000).toLong()
+        }
+    }
+}

--- a/android/src/main/java/com/doublesymmetry/trackplayer/model/TrackMetadata.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/model/TrackMetadata.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.RatingCompat
+import com.doublesymmetry.trackplayer.extensions.NumberExt.Companion.toMilliseconds
 import com.doublesymmetry.trackplayer.utils.Utils
 
 abstract class TrackMetadata {
@@ -23,7 +24,7 @@ abstract class TrackMetadata {
         album = bundle.getString("album")
         date = bundle.getString("date")
         genre = bundle.getString("genre")
-        duration = Utils.toMillis(bundle.getDouble("duration", 0.0))
+        duration = (bundle.getDouble("duration", 0.0)).toMilliseconds()
         rating = Utils.getRating(bundle, "rating", ratingType)
     }
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -8,6 +8,7 @@ import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.doublesymmetry.kotlinaudio.models.Capability
 import com.doublesymmetry.kotlinaudio.models.RepeatMode
+import com.doublesymmetry.trackplayer.extensions.NumberExt.Companion.toMilliseconds
 import com.doublesymmetry.trackplayer.extensions.asLibState
 import com.doublesymmetry.trackplayer.model.State
 import com.doublesymmetry.trackplayer.model.Track
@@ -139,14 +140,10 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
 
         // Validate buffer keys.
         val bundledData = Arguments.toBundle(data)
-        val minBuffer = bundledData?.getDouble(MusicService.MIN_BUFFER_KEY)
-                ?.let { Utils.toMillis(it).toInt() } ?: DEFAULT_MIN_BUFFER_MS
-        val maxBuffer = bundledData?.getDouble(MusicService.MAX_BUFFER_KEY)
-                ?.let { Utils.toMillis(it).toInt() } ?: DEFAULT_MAX_BUFFER_MS
-        val playBuffer = bundledData?.getDouble(MusicService.PLAY_BUFFER_KEY)
-                ?.let { Utils.toMillis(it).toInt() } ?: DEFAULT_BUFFER_FOR_PLAYBACK_MS
-        val backBuffer = bundledData?.getDouble(MusicService.BACK_BUFFER_KEY)
-                ?.let { Utils.toMillis(it).toInt() } ?: DEFAULT_BACK_BUFFER_DURATION_MS
+        val minBuffer = bundledData?.getDouble(MusicService.MIN_BUFFER_KEY)?.toMilliseconds()?.toInt() ?: DEFAULT_MIN_BUFFER_MS
+        val maxBuffer = bundledData?.getDouble(MusicService.MAX_BUFFER_KEY)?.toMilliseconds()?.toInt() ?: DEFAULT_MAX_BUFFER_MS
+        val playBuffer = bundledData?.getDouble(MusicService.PLAY_BUFFER_KEY)?.toMilliseconds()?.toInt() ?: DEFAULT_BUFFER_FOR_PLAYBACK_MS
+        val backBuffer = bundledData?.getDouble(MusicService.BACK_BUFFER_KEY)?.toMilliseconds()?.toInt() ?: DEFAULT_BACK_BUFFER_DURATION_MS
 
         if (playBuffer < 0) {
             promise.reject(

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -26,7 +26,6 @@ import com.facebook.react.HeadlessJsTaskService
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import java.util.concurrent.TimeUnit
 
@@ -263,7 +262,7 @@ class MusicService : HeadlessJsTaskService() {
 
     @MainThread
     fun seekTo(seconds: Float) {
-        player.seek((seconds * 1000).toLong(), TimeUnit.MILLISECONDS)
+        player.seek((seconds.toMilliseconds()), TimeUnit.MILLISECONDS)
     }
 
     @MainThread
@@ -294,13 +293,13 @@ class MusicService : HeadlessJsTaskService() {
     }
 
     @MainThread
-    fun getDurationInSeconds(): Double = player.duration.toDouble() / 1000
+    fun getDurationInSeconds(): Double = player.duration.toSeconds()
 
     @MainThread
-    fun getPositionInSeconds(): Double = player.position.toDouble() / 1000
+    fun getPositionInSeconds(): Double = player.position.toSeconds()
 
     @MainThread
-    fun getBufferedPositionInSeconds(): Double = player.bufferedPosition.toDouble() / 1000
+    fun getBufferedPositionInSeconds(): Double = player.bufferedPosition.toSeconds()
 
     @MainThread
     fun updateMetadataForTrack(index: Int, track: Track) {

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -424,7 +424,12 @@ class MusicService : HeadlessJsTaskService() {
                             emit(MusicEvents.BUTTON_SET_RATING, this)
                         }
                     }
-                    else -> {}
+                    is MediaSessionCallback.SEEK -> {
+                        Bundle().apply {
+                            putDouble("position", it.position.toDouble())
+                            emit(MusicEvents.BUTTON_SEEK_TO, this)
+                        }
+                    }
                 }
             }
         }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -380,8 +380,8 @@ class MusicService : HeadlessJsTaskService() {
                     is FORWARD -> {
                         Bundle().apply {
                             val interval = latestOptions?.getDouble(
-                                FORWARD_JUMP_INTERVAL_KEY,
-                                DEFAULT_JUMP_INTERVAL,
+                                    FORWARD_JUMP_INTERVAL_KEY,
+                                    DEFAULT_JUMP_INTERVAL,
                             ) ?: DEFAULT_JUMP_INTERVAL
                             putInt("interval", interval.toInt())
                             emit(MusicEvents.BUTTON_JUMP_FORWARD, this)
@@ -390,8 +390,8 @@ class MusicService : HeadlessJsTaskService() {
                     is BACKWARD -> {
                         Bundle().apply {
                             val interval = latestOptions?.getDouble(
-                                BACKWARD_JUMP_INTERVAL_KEY,
-                                DEFAULT_JUMP_INTERVAL,
+                                    BACKWARD_JUMP_INTERVAL_KEY,
+                                    DEFAULT_JUMP_INTERVAL,
                             ) ?: DEFAULT_JUMP_INTERVAL
                             putInt("interval", interval.toInt())
                             emit(MusicEvents.BUTTON_JUMP_BACKWARD, this)

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -344,10 +344,10 @@ class MusicService : HeadlessJsTaskService() {
 
                     // correctly set the previous index on the event payload
                     var previousIndex: Int? = null
-                    if (it == AudioItemTransitionReason.REPEAT) {
+                    if (it is AudioItemTransitionReason.REPEAT) {
                         previousIndex = player.currentIndex
                     } else if (player.previousItem != null) {
-                        previousIndex = player?.previousIndex
+                        previousIndex = player.previousIndex
                     }
 
                     if (previousIndex != null) {
@@ -424,12 +424,7 @@ class MusicService : HeadlessJsTaskService() {
                             emit(MusicEvents.BUTTON_SET_RATING, this)
                         }
                     }
-                    is MediaSessionCallback.SEEK -> {
-                        Bundle().apply {
-                            putDouble("position", it.position.toDouble())
-                            emit(MusicEvents.BUTTON_SEEK_TO, this)
-                        }
-                    }
+                    else -> {}
                 }
             }
         }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/utils/Utils.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/utils/Utils.kt
@@ -11,14 +11,6 @@ import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
  * @author Milen Pivchev @mpivchev
  */
 object Utils {
-    fun toMillis(seconds: Double): Long {
-        return (seconds * 1000).toLong()
-    }
-
-    fun toSeconds(millis: Long): Double {
-        return millis / 1000.0
-    }
-
     fun getUri(context: Context, data: Bundle?, key: String?): Uri? {
         if (!data!!.containsKey(key)) return null
         val obj = data[key]


### PR DESCRIPTION
This is a followup to https://github.com/doublesymmetry/KotlinAudio/pull/36 which fixes https://github.com/doublesymmetry/react-native-track-player/issues/1613