### PR TITLE
Remove ExoPlayer fork dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,8 +51,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.DoubleSymmetry:KotlinAudio:v1.0'
-//    implementation "com.github.doublesymmetry:kotlin-audio:1.0"
+//    implementation 'com.github.DoubleSymmetry:KotlinAudio:v1.0'
+    implementation "com.github.doublesymmetry:kotlin-audio:1.1.0"
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,8 +51,8 @@ repositories {
 }
 
 dependencies {
-//    implementation 'com.github.DoubleSymmetry:KotlinAudio:v1.0'
-    implementation "com.github.doublesymmetry:kotlin-audio:1.1.0"
+    implementation 'com.github.DoubleSymmetry:KotlinAudio:v1.1.0'
+//    implementation "com.github.doublesymmetry:kotlin-audio:1.1.0"
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -372,7 +372,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     fun reset(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
 
-        musicService.reset()
+        musicService.stopPlayer()
         callback.resolve(null)
     }
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -4,7 +4,6 @@ import android.content.*
 import android.os.Bundle
 import android.os.IBinder
 import android.support.v4.media.RatingCompat
-import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.doublesymmetry.kotlinaudio.models.Capability
 import com.doublesymmetry.kotlinaudio.models.RepeatMode
@@ -188,7 +187,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     }
 
     @ReactMethod
-    @Deprecated("Backwards compatible function from the old android implementation. Should be removed in V3")
+    @Deprecated("Backwards compatible function from the old android implementation. Should be removed in the next major release.")
     fun isServiceRunning(callback: Promise) {
         callback.resolve(isServiceBound)
     }
@@ -373,7 +372,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     fun reset(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
 
-        musicService.stopPlayer()
+        musicService.reset()
         callback.resolve(null)
     }
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -46,9 +46,9 @@ class MusicService : HeadlessJsTaskService() {
         get() = (player.currentItem as TrackAudioItem).track
 
     var ratingType: Int
-        get() = player.notificationManager.ratingType
+        get() = player.ratingType
         set(value) {
-            player.notificationManager.ratingType = value
+            player.ratingType = value
         }
 
     val event get() = player.event
@@ -65,7 +65,6 @@ class MusicService : HeadlessJsTaskService() {
 
     @MainThread
     fun setupPlayer(playerOptions: Bundle?) {
-        // fun setupPlayer(playerOptions: Bundle?) {
         val bufferOptions = BufferConfig(
                 playerOptions?.getDouble(MIN_BUFFER_KEY)?.toMilliseconds()?.toInt(),
                 playerOptions?.getDouble(MAX_BUFFER_KEY)?.toMilliseconds()?.toInt(),
@@ -113,7 +112,7 @@ class MusicService : HeadlessJsTaskService() {
                 }
                 Capability.STOP -> {
                     val stopIcon = Utils.getIconOrNull(this, options, "stopIcon")
-                    buttonsList.add(STOP(icon = stopIcon, isCompact = isCompact(it)))
+                    buttonsList.add(STOP(icon = stopIcon))
                 }
                 Capability.SKIP_TO_NEXT -> {
                     val nextIcon = Utils.getIconOrNull(this, options, "nextIcon")
@@ -313,7 +312,7 @@ class MusicService : HeadlessJsTaskService() {
 
     @MainThread
     fun clearNotificationMetadata() {
-        player.notificationManager.clearNotification()
+        player.notificationManager.hideNotification()
     }
 
     @MainThread
@@ -428,6 +427,31 @@ class MusicService : HeadlessJsTaskService() {
                         Bundle().apply {
                             putDouble("position", it.position.toDouble())
                             emit(MusicEvents.BUTTON_SEEK_TO, this)
+                        }
+                    }
+                    MediaSessionCallback.PLAY -> emit(MusicEvents.BUTTON_PLAY)
+                    MediaSessionCallback.PAUSE -> emit(MusicEvents.BUTTON_PAUSE)
+                    MediaSessionCallback.NEXT -> emit(MusicEvents.BUTTON_SKIP_NEXT)
+                    MediaSessionCallback.PREVIOUS -> emit(MusicEvents.BUTTON_SKIP_PREVIOUS)
+                    MediaSessionCallback.STOP -> emit(MusicEvents.BUTTON_STOP)
+                    MediaSessionCallback.FORWARD -> {
+                        Bundle().apply {
+                            val interval = latestOptions?.getDouble(
+                                    FORWARD_JUMP_INTERVAL_KEY,
+                                    DEFAULT_JUMP_INTERVAL,
+                            ) ?: DEFAULT_JUMP_INTERVAL
+                            putInt("interval", interval.toInt())
+                            emit(MusicEvents.BUTTON_JUMP_FORWARD, this)
+                        }
+                    }
+                    MediaSessionCallback.REWIND -> {
+                        Bundle().apply {
+                            val interval = latestOptions?.getDouble(
+                                    BACKWARD_JUMP_INTERVAL_KEY,
+                                    DEFAULT_JUMP_INTERVAL,
+                            ) ?: DEFAULT_JUMP_INTERVAL
+                            putInt("interval", interval.toInt())
+                            emit(MusicEvents.BUTTON_JUMP_BACKWARD, this)
                         }
                     }
                 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -369,39 +369,6 @@ class MusicService : HeadlessJsTaskService() {
         }
 
         scope.launch {
-            event.onNotificationButtonTapped.collect {
-                when (it) {
-                    is PLAY -> emit(MusicEvents.BUTTON_PLAY)
-                    is PAUSE -> emit(MusicEvents.BUTTON_PAUSE)
-                    is NEXT -> emit(MusicEvents.BUTTON_SKIP_NEXT)
-                    is PREVIOUS -> emit(MusicEvents.BUTTON_SKIP_PREVIOUS)
-                    is STOP -> emit(MusicEvents.BUTTON_STOP)
-                    is FORWARD -> {
-                        Bundle().apply {
-                            val interval = latestOptions?.getDouble(
-                                    FORWARD_JUMP_INTERVAL_KEY,
-                                    DEFAULT_JUMP_INTERVAL,
-                            ) ?: DEFAULT_JUMP_INTERVAL
-                            putInt("interval", interval.toInt())
-                            emit(MusicEvents.BUTTON_JUMP_FORWARD, this)
-                        }
-                    }
-                    is BACKWARD -> {
-                        Bundle().apply {
-                            val interval = latestOptions?.getDouble(
-                                    BACKWARD_JUMP_INTERVAL_KEY,
-                                    DEFAULT_JUMP_INTERVAL,
-                            ) ?: DEFAULT_JUMP_INTERVAL
-                            putInt("interval", interval.toInt())
-                            emit(MusicEvents.BUTTON_JUMP_BACKWARD, this)
-                        }
-                    }
-                }
-
-            }
-        }
-
-        scope.launch {
             event.notificationStateChange.collect {
                 when (it) {
                     is NotificationState.POSTED -> {
@@ -436,20 +403,14 @@ class MusicService : HeadlessJsTaskService() {
                     MediaSessionCallback.STOP -> emit(MusicEvents.BUTTON_STOP)
                     MediaSessionCallback.FORWARD -> {
                         Bundle().apply {
-                            val interval = latestOptions?.getDouble(
-                                    FORWARD_JUMP_INTERVAL_KEY,
-                                    DEFAULT_JUMP_INTERVAL,
-                            ) ?: DEFAULT_JUMP_INTERVAL
+                            val interval = latestOptions?.getDouble(FORWARD_JUMP_INTERVAL_KEY, DEFAULT_JUMP_INTERVAL) ?: DEFAULT_JUMP_INTERVAL
                             putInt("interval", interval.toInt())
                             emit(MusicEvents.BUTTON_JUMP_FORWARD, this)
                         }
                     }
                     MediaSessionCallback.REWIND -> {
                         Bundle().apply {
-                            val interval = latestOptions?.getDouble(
-                                    BACKWARD_JUMP_INTERVAL_KEY,
-                                    DEFAULT_JUMP_INTERVAL,
-                            ) ?: DEFAULT_JUMP_INTERVAL
+                            val interval = latestOptions?.getDouble(BACKWARD_JUMP_INTERVAL_KEY, DEFAULT_JUMP_INTERVAL) ?: DEFAULT_JUMP_INTERVAL
                             putInt("interval", interval.toInt())
                             emit(MusicEvents.BUTTON_JUMP_BACKWARD, this)
                         }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -229,9 +229,8 @@ class MusicService : HeadlessJsTaskService() {
     }
 
     @MainThread
-    fun reset() {
-        player.pause()
-        player.clearQueue()
+    fun stopPlayer() {
+        player.stop()
     }
 
     @MainThread
@@ -469,8 +468,7 @@ class MusicService : HeadlessJsTaskService() {
     @MainThread
     override fun onDestroy() {
         super.onDestroy()
-
-        reset()
+        player.stop()
     }
 
     @MainThread

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -229,9 +229,9 @@ class MusicService : HeadlessJsTaskService() {
     }
 
     @MainThread
-    fun stopPlayer() {
-        player.stop()
-        player.destroy()
+    fun reset() {
+        player.pause()
+        player.clearQueue()
     }
 
     @MainThread
@@ -470,7 +470,7 @@ class MusicService : HeadlessJsTaskService() {
     override fun onDestroy() {
         super.onDestroy()
 
-        stopPlayer()
+        reset()
     }
 
     @MainThread

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-track-player",
-  "version": "2.2.0-rc3",
+  "version": "3.0.0",
   "description": "A fully fledged audio module created for music apps",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
This PR is a follow up of https://github.com/doublesymmetry/KotlinAudio/pull/38

1. This PR removes the ExoPlayer fork dependacy we had, fixing #17 and https://github.com/doublesymmetry/react-native-track-player/issues/1418
2. This PR will also enable bluetooth/physical button media control.
3. It provides Android with proper metadata for the current track, allowing it to populate lock screens and AODs. Can indirectly fix #27, but more tests need to be done.
Example of lock screen: 
<img width="140" alt="image" src="https://user-images.githubusercontent.com/6960329/185164327-ab39917f-a362-4cef-aa0e-c924c80f8d77.png">


