### PR TITLE
docs(v3): add minimum react native version

### DIFF
--- a/docs/versioned_docs/version-3.1/v3-migration.md
+++ b/docs/versioned_docs/version-3.1/v3-migration.md
@@ -17,6 +17,7 @@ how other popular apps (Spotify, Soundcloud, Google Podcasts, etc.) work.
 - The `destroy` function does not exist anymore. 
 - The `stopWithApp` flag turns into `stoppingAppPausesPlayback` 
     - [More information here](https://github.com/doublesymmetry/react-native-track-player/pull/1447#issuecomment-1195246389)
+- The react-native version has to be 0.68 or higher
 
 The full changelog of added features and bug fixes [can be found here](https://github.com/doublesymmetry/react-native-track-player/releases/tag/v3.0).
 


### PR DESCRIPTION
When upgrading from v2.1.3 to v3.1 an error occurs that requires an upgrade from 30 to 31 for these 2 in `android/build.gradle`:

```
        compileSdkVersion = 31
        targetSdkVersion = 31
```

According to https://react-native-community.github.io/upgrade-helper/?from=0.67.4&to=0.68.0 this is done when upgrading to react-native v0.68.0.