### PR TITLE
fix(example, ios): remove Capability.Stop

### DIFF
--- a/example/src/services/SetupService.ts
+++ b/example/src/services/SetupService.ts
@@ -15,7 +15,6 @@ export const SetupService = async (): Promise<boolean> => {
         Capability.Pause,
         Capability.SkipToNext,
         Capability.SkipToPrevious,
-        Capability.Stop,
         Capability.SeekTo,
       ],
       compactCapabilities: [


### PR DESCRIPTION
Capability.Stop was causing a not-functioning stop button to be shown in the iOs lock screen. Removing Capability.Stop causes the pause button to be shown instead. The pause button is functioning because we are listening for Event.RemotePause.