### PR TITLE
chore(hooks): use progressUpdateEventInterval

### DIFF
--- a/example/src/components/Progress.tsx
+++ b/example/src/components/Progress.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
 import Slider from '@react-native-community/slider';
-import TrackPlayer, { useProgress } from 'react-native-track-player';
+import React from 'react';
+import {StyleSheet, Text, View} from 'react-native';
+import TrackPlayer, {useProgress} from 'react-native-track-player';
 
 export const Progress: React.FC = () => {
-  const progress = useProgress();
+  const progress = useProgress(2000);
   return (
     <>
       <Slider

--- a/example/src/services/SetupService.ts
+++ b/example/src/services/SetupService.ts
@@ -24,7 +24,6 @@ export const SetupService = async (): Promise<boolean> => {
         Capability.SkipToNext,
         Capability.SeekTo,
       ],
-      progressUpdateEventInterval: 2,
     });
 
     isSetup = true;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -78,60 +78,18 @@ export const useTrackPlayerEvents = <T extends Event[], H extends (data: EventsP
 }
 
 /**
- * Poll for track progress for the given interval (in miliseconds)
- * @param interval - ms interval
+ * A hook that returns the current playback progress
+ * @param updateInterval The interval in ms at which the progress is updated
  */
-export function useProgress(updateInterval?: number) {
+export function useProgress(updateInterval = 1000) {
+  useEffect(() => {
+    if (updateInterval) {
+      TrackPlayer.updateOptions({ progressUpdateEventInterval: updateInterval * 0.001 })
+    }
+  }, [updateInterval])
+
   const [state, setState] = useState<Progress>({ position: 0, duration: 0, buffered: 0 })
-  const playerState = usePlaybackState()
-  const stateRef = useRef(state)
-  const isUnmountedRef = useRef(true)
-
-  useEffect(() => {
-    isUnmountedRef.current = false
-    return () => {
-      isUnmountedRef.current = true
-    }
-  }, [])
-
-  const getProgress = async () => {
-    try {
-      const [position, duration, buffered] = await Promise.all([
-        TrackPlayer.getPosition(),
-        TrackPlayer.getDuration(),
-        TrackPlayer.getBufferedPosition(),
-      ])
-
-      // If the component has been unmounted, exit
-      if (isUnmountedRef.current) return
-
-      // If there is no change in properties, exit
-      if (
-        position === stateRef.current.position &&
-        duration === stateRef.current.duration &&
-        buffered === stateRef.current.buffered
-      )
-        return
-
-      const state = { position, duration, buffered }
-      stateRef.current = state
-      setState(state)
-    } catch {} // these method only throw while you haven't yet setup, ignore failure.
-  }
-
-  useEffect(() => {
-    if (playerState === State.None) {
-      setState({ position: 0, duration: 0, buffered: 0 })
-      return
-    }
-
-    // Set initial state
-    getProgress()
-
-    // Create interval to update state periodically
-    const poll = setInterval(getProgress, updateInterval || 1000)
-    return () => clearInterval(poll)
-  }, [playerState, updateInterval])
+  useTrackPlayerEvents([Event.PlaybackProgressUpdated], setState)
 
   return state
 }


### PR DESCRIPTION
This pull request uses the new `progressUpdateEventInterval` functionality for the `useProgress` hook.

Something to note is that calling the hook also calls TrackPlayer.setOptions to set the `progressUpdateEventInterval`.

@jspizziri I would be interested to hear your thoughts on this implementation!