### PR TITLE
fix(queue): do nothing when queue is empty (#1679)

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -324,8 +324,9 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     @ReactMethod
     fun removeUpcomingTracks(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
-
-        musicService.removeUpcomingTracks()
+        if(musicService.tracks.isNotEmpty()) {
+            musicService.removeUpcomingTracks()
+        }
         callback.resolve(null)
     }
 


### PR DESCRIPTION
Doing something like this would temporary fix #1679, until the inner issue https://github.com/doublesymmetry/KotlinAudio/pull/41 gets fixed.

