### PR TITLE
chore(example): format example

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -33,7 +33,7 @@ const App: React.FC = () => {
   if (!isPlayerReady) {
     return (
       <SafeAreaView style={styles.screenContainer}>
-        <ActivityIndicator/>
+        <ActivityIndicator />
       </SafeAreaView>
     );
   }
@@ -49,11 +49,11 @@ const App: React.FC = () => {
             type="primary"
           />
         </View>
-        <TrackInfo track={track}/>
+        <TrackInfo track={track} />
         <Progress />
       </View>
       <View style={styles.actionRowContainer}>
-        <PlayerControls/>
+        <PlayerControls />
       </View>
     </SafeAreaView>
   );

--- a/example/src/components/Button.tsx
+++ b/example/src/components/Button.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  TouchableWithoutFeedback,
-} from 'react-native';
+import {StyleSheet, Text, TouchableWithoutFeedback} from 'react-native';
 
 export interface ButtonProps {
   title: string;

--- a/example/src/components/PlayerControls.tsx
+++ b/example/src/components/PlayerControls.tsx
@@ -7,7 +7,7 @@ import {PlayPauseButton} from './PlayPauseButton';
 
 export const PlayerControls: React.FC = () => {
   return (
-    <View style={{ width: '100%' }}>
+    <View style={{width: '100%'}}>
       <View style={styles.row}>
         <Button
           title="Prev"
@@ -31,6 +31,6 @@ const styles = StyleSheet.create({
   },
   row: {
     flexDirection: 'row',
-    justifyContent: 'space-evenly'
+    justifyContent: 'space-evenly',
   },
 });

--- a/example/src/components/Progress.tsx
+++ b/example/src/components/Progress.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import {StyleSheet, Text, View} from 'react-native';
 import Slider from '@react-native-community/slider';
-import TrackPlayer, { useProgress } from 'react-native-track-player';
+import TrackPlayer, {useProgress} from 'react-native-track-player';
 
 export const Progress: React.FC = () => {
   const progress = useProgress();

--- a/example/src/components/TrackInfo.tsx
+++ b/example/src/components/TrackInfo.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
-import {
-  Image,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import {Image, StyleSheet, Text, View} from 'react-native';
 import type {Track} from 'react-native-track-player';
 
 export interface TrackInfoProps {
   track?: Track;
 }
 
-export const TrackInfo: React.FC<TrackInfoProps> = ({ track }) => {
+export const TrackInfo: React.FC<TrackInfoProps> = ({track}) => {
   return (
     <View style={styles.container}>
       <Image style={styles.artwork} source={{uri: `${track?.artwork}`}} />

--- a/example/src/hooks/useCurrentTrack.ts
+++ b/example/src/hooks/useCurrentTrack.ts
@@ -1,17 +1,17 @@
 import {useState, useEffect} from 'react';
-import TrackPlayer, {useTrackPlayerEvents, Event} from 'react-native-track-player';
+import TrackPlayer, {
+  useTrackPlayerEvents,
+  Event,
+} from 'react-native-track-player';
 import type {Track} from 'react-native-track-player';
 
-export const useCurrentTrack = (): Track|undefined => {
+export const useCurrentTrack = (): Track | undefined => {
   const [index, setIndex] = useState<number | undefined>();
   const [track, setTrack] = useState<Track | undefined>();
 
-  useTrackPlayerEvents(
-    [Event.PlaybackTrackChanged],
-    async ({ nextTrack }) => {
-      setIndex(nextTrack);
-    },
-  );
+  useTrackPlayerEvents([Event.PlaybackTrackChanged], async ({nextTrack}) => {
+    setIndex(nextTrack);
+  });
 
   useEffect(() => {
     if (index === undefined) return;

--- a/example/src/services/PlaybackService.ts
+++ b/example/src/services/PlaybackService.ts
@@ -1,4 +1,4 @@
-import TrackPlayer, { Event, State } from 'react-native-track-player';
+import TrackPlayer, {Event, State} from 'react-native-track-player';
 
 let wasPausedByDuck = false;
 


### PR DESCRIPTION
Ran everything in example/src through prettier, to avoid having these whitespace changes showing up in other pull requests. Maybe we need to add something to the ci to also check for this?

I think this comes from the fact that the .prettierrc.js in the example directory has different settings to that in the rntp directory itself. When you edit the example app through the rntp directory in vscode, it will use rntp/.prettierrc.js instead of rntp/example/.prettierrc.js

Perhaps we might unify the two to avoid running into this in the future?