### PR TITLE
Dismiss notification when app is removed from recent apps list

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -456,7 +456,7 @@ class MusicService : HeadlessJsTaskService() {
         super.onTaskRemoved(rootIntent)
 
         if (stoppingAppPausesPlayback) {
-            player.pause()
+            player.stop()
         }
     }
 


### PR DESCRIPTION
With version 3.1.0 the multimedia notification is not dismissed when the app has been terminated by the user. The only way to dismiss the notification is to force quit the app from the settings. I have made these changes to prevent this behavior, now when the user kills the app the notification also closes.