### PR TITLE
chore(example): improve sync scripts

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src",
     "sync:ios": "yarn rimraf ../ios && yarn cpx 'node_modules/react-native-track-player/ios/**' ../ios",
     "sync:android": "yarn rimraf ../android && yarn cpx 'node_modules/react-native-track-player/android/**' ../android",
+    "sync:swift-audio": "scripts/sync-swift-audio",
     "sync": "yarn sync:ios && yarn sync:android",
     "fresh": "rm -rf node_modules ; cd .. && yarn build ; cd example && yarn install",
     "types": "tsc --noEmit true",

--- a/example/scripts/sync-swift-audio
+++ b/example/scripts/sync-swift-audio
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+DIRECTORY=$(cd "$(dirname "$0")" && pwd)
+SOURCE=$(realpath "$DIRECTORY/../ios/Pods/SwiftAudioEx/SwiftAudioEx")
+TARGET=$(realpath "$DIRECTORY/../../../SwiftAudioEx/SwiftAudioEx")
+
+if [ ! -d "$SOURCE" ]; then
+    echo "This script relies on the directory \"$SOURCE\" to exist. Aborting."
+    exit 1
+fi
+
+rm -rf "$TARGET"
+cp -R "$SOURCE" "$TARGET"
+
+echo "Copied files from \"$SOURCE\" to \"$TARGET\""


### PR DESCRIPTION
- [x] Implement `"sync:swift-audio"` command
- [ ] Refactor `scripts/sync-swift-audio` to accept `target` and `destination` arguments and reuse in other scripts
- [ ] Implement `"sync:kotlin-audio"` command