### PR TITLE
fix(hooks): useProgress & usePlayback hooks

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -3,8 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Event, EventsPayloadByEvent, Progress, State } from './interfaces';
 import TrackPlayer from './trackPlayer';
 
-/** Get current playback state and subsequent updates  */
-export const usePlaybackState = () => {
+const usePlaybackStateWithoutInitialValue = () => {
   const [state, setState] = useState<State | undefined>(undefined);
   useEffect(() => {
     let mounted = true;
@@ -33,6 +32,12 @@ export const usePlaybackState = () => {
   }, []);
 
   return state;
+};
+
+/** Get current playback state and subsequent updates  */
+export const usePlaybackState = () => {
+  const state = usePlaybackStateWithoutInitialValue();
+  return state ?? State.None;
 };
 
 /**
@@ -88,7 +93,7 @@ export function useProgress(updateInterval = 1000) {
     duration: 0,
     buffered: 0,
   });
-  const playerState = usePlaybackState();
+  const playerState = usePlaybackStateWithoutInitialValue();
   const isNone = playerState === State.None;
   useEffect(() => {
     let mounted = true;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,7 +5,7 @@ import TrackPlayer from './trackPlayer';
 
 /** Get current playback state and subsequent updates  */
 export const usePlaybackState = () => {
-  const [state, setState] = useState(State.None);
+  const [state, setState] = useState<State | undefined>(undefined);
   useEffect(() => {
     let mounted = true;
 
@@ -89,10 +89,10 @@ export function useProgress(updateInterval = 1000) {
     buffered: 0,
   });
   const playerState = usePlaybackState();
-
+  const isNone = playerState === State.None;
   useEffect(() => {
     let mounted = true;
-    if (playerState === State.None) {
+    if (isNone) {
       setState({ position: 0, duration: 0, buffered: 0 });
       return;
     }
@@ -131,7 +131,7 @@ export function useProgress(updateInterval = 1000) {
     return () => {
       mounted = false;
     };
-  }, [playerState, updateInterval]);
+  }, [isNone, updateInterval]);
 
   return state;
 }


### PR DESCRIPTION
- (breaking) fix: usePlaybackState was incorrectly returning `State.None` by default. Now it returns undefined while it is waiting on the async call to TrackPlayer to resolve. This also fixes the following issue where duration was incorrectly being reported as `0`: https://github.com/doublesymmetry/react-native-track-player/issues/1709
- optimization: avoid unnecessarily reevaluating the useEffect on every player state change by moving the `playerState === State.None` outside of the effect and including it as a dependency instead