### PR TITLE
feat(android): add string values to State enum

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/model/State.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/model/State.kt
@@ -1,11 +1,11 @@
 package com.doublesymmetry.trackplayer.model
 
-enum class State {
-    Idle,
-    Ready,
-    Playing,
-    Paused,
-    Stopped,
-    Buffering,
-    Connecting,
+enum class State(val state: String) {
+    Idle("idle"),
+    Ready("ready"),
+    Playing("playing"),
+    Paused("paused"),
+    Stopped("stopped"),
+    Buffering("buffering"),
+    Connecting("connecting"),
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -502,7 +502,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         if (!::musicService.isInitialized) {
             callback.resolve(State.Idle.ordinal)
         } else {
-            callback.resolve(musicService.event.stateChange.value.asLibState.ordinal)
+            callback.resolve(musicService.event.stateChange.value.asLibState.state)
         }
     }
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -323,7 +323,7 @@ class MusicService : HeadlessJsTaskService() {
         scope.launch {
             event.stateChange.collect {
                 val bundle = Bundle()
-                bundle.putInt(STATE_KEY, it.asLibState.ordinal)
+                bundle.putString(STATE_KEY, it.asLibState.state)
                 emit(MusicEvents.PLAYBACK_STATE, bundle)
 
                 if (it == AudioPlayerState.ENDED && player.nextItem == null) {


### PR DESCRIPTION
- fixes #1688
- adds string values to State enum. These values are identical to those on iOS
- emits them as string from `MusicEvents.PLAYBACK_STATE`
- returns them as string from `MusicModule#getState`