### PR TITLE
Allow void return value from PlaybackService ServiceHandler

### DIFF
--- a/docs/versioned_docs/version-3.2/api/functions/lifecycle.md
+++ b/docs/versioned_docs/version-3.2/api/functions/lifecycle.md
@@ -35,7 +35,7 @@ You should use the playback service to register the event handlers that must be 
 
 | Param   | Type     | Description   |
 | ------- | -------- | ------------- |
-| serviceProvider | `function` | The function that must return an async service function. |
+| serviceProvider | `function` | The function that returns the playback service function. |
 
 ## `useTrackPlayerEvents(events: Event[], handler: Handler)`
 

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -41,7 +41,7 @@ async function setupPlayer(options: PlayerOptions = {}): Promise<void> {
   return TrackPlayer.setupPlayer(options || {});
 }
 
-type ServiceHandler = () => Promise<void>;
+type ServiceHandler = () => void | Promise<void>;
 /**
  * Register the playback service. The service will run as long as the player runs.
  */


### PR DESCRIPTION
I don't need my playback-service to be async, as I've outsourced all the work to another service file.

Though we should keep the documentation and examples demonstrating an async service, it doesn't need to be enforced right? The callback is fired fine regardless of it's return type.

See my playback-service screenshot...

Thoughts?

![Screen Shot 2022-09-27 at 11 31 06](https://user-images.githubusercontent.com/1085976/192410470-4cc0658c-53f4-4614-8020-637fef8a5f86.png)
