### PR TITLE
docs(api): clarify type of `.remove()` and `.add()` methods

### DIFF
--- a/docs/versioned_docs/version-3.2/api/functions/queue.md
+++ b/docs/versioned_docs/version-3.2/api/functions/queue.md
@@ -18,7 +18,7 @@ Removes one or more tracks from the queue.
 
 | Param  | Type     | Description   |
 | ------ | -------- | ------------- |
-| tracks | `array` of track indexes or a single one | The tracks that will be removed |
+| tracks | `number` or an `array` of `number` | The index(es) of track(s) to be removed from the queue |
 
 ## `skip(index, initialPosition)`
 Skips to a track in the queue.


### PR DESCRIPTION
Just to make this clearer.

I would rather use TS typing and just have `number[]` but I think that won't be clear enough to everyone. Thoughts?