### PR TITLE
docs(player.md): updated docs to avoid audio word drops at fast rates

### DIFF
--- a/docs/docs/api/functions/player.md
+++ b/docs/docs/api/functions/player.md
@@ -45,6 +45,9 @@ Sets the playback rate
 | ------ | -------- | --------------------------------- |
 | rate   | `number` | The playback rate where 1 is the regular speed |
 
+**Note:** If your rate is high, e.g. above 2, you may want to set the track's `pitchAlgorithm` to something like `PitchAlgorithm.Voice`, or else the default pitch algorithm (which in `SwiftAudioEx` drops down to `AVAudioTimePitchAlgorithm.lowQualityZeroLatency`) will likely
+drop words in your audio.
+
 ## `getRate()`
 Gets the playback rate, where 1 is the regular speed.
 


### PR DESCRIPTION
The default AudioItem in SwiftAudioEx drops you down to the low-quality, zero-latency pitch algorithm. But at high speeds (e.g. beyond 2x), it ends up dropping words from audio all the time. This updates the documentation to recommend a tweak for people that avoids this problem. Note that the ideal case would be to actually change the default pitch algorithm to avoid this problem.

fix #1837