### PR TITLE
V3.2

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,14 +13,6 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
         </service>
-
-        <!-- A receiver that will receive media buttons. Required on pre-lollipop devices -->
-        <receiver android:name="androidx.media.session.MediaButtonReceiver" android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MEDIA_BUTTON" />
-            </intent-filter>
-        </receiver>
-
     </application>
 
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <application>
 
         <!-- The main service, handles playback, playlists and media buttons -->
-        <service android:name="com.doublesymmetry.trackplayer.service.MusicService" android:enabled="true" android:exported="false">
+        <service android:name="com.doublesymmetry.trackplayer.service.MusicService" android:enabled="true" android:exported="true" android:foregroundServiceType="mediaPlayback">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>


### PR DESCRIPTION
The first commit removes the static MediaButtonReceiver which is causing a lot of RemoteServiceExceptions, and a group of other related exceptions, most of them mentioned in [this issue](https://github.com/doublesymmetry/react-native-track-player/issues/1676). This change made all of the related errors go away in our production environment, and has been running there for almost a month now. @elliotdickison has also reported the same.

As seen [here](https://developer.android.com/reference/androidx/media/session/MediaButtonReceiver) a service can also receive media button actions: `A service can receive a key event by including an intent filter that handles [ACTION_MEDIA_BUTTON](https://developer.android.com/reference/android/content/Intent.html#ACTION_MEDIA_BUTTON())` which is already registered in the manifest, and it seems to work just fine. We have verified with a connected bluetooth headset that skip, play and pause is still working when originating from the headset. It would be great if you could test the PR and verify it with other devices as well.

The last commit exporting the MusicService and setting foregroundServiceType is not tested in production yet, but should be set as I gather from [this page](https://developer.android.com/guide/topics/manifest/service-element)

Sorry for the wall of text. Please advise if anything should be changed.