### PR TITLE
Fix MusicModule remove track function to use correct array

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -301,7 +301,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         if (inputIndexes != null) {
             val size = musicService.tracks.size
             var indexes: ArrayList<Int> = ArrayList();
-            for (inputIndex in indexes) {
+            for (inputIndex in inputIndexes) {
                 val index = if (inputIndex is Int) inputIndex else inputIndex.toString().toInt()
                 if (index < 0 || index >= size) {
                     callback.reject(


### PR DESCRIPTION
I'm using the 3.2.0-11137d56135ed2b47ae5f9a5713c1560e6d65f1c version, and it seems like the `.remove(track)` is broken. I looked into it and it might be as simple as an incorrect variable name? The fix seems to be working in my local tests.