### PR TITLE
fix: clears queue on iOS when you call reset()

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -505,6 +505,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         if (rejectWhenNotInitialized(reject: reject)) { return }
 
         player.stop()
+        player.clear()
         resolve(NSNull())
     }
 


### PR DESCRIPTION
Android always did this correctly, but iOS hasn't. You basically need to not only stop playback, but actually clear the queue, when `reset()` is called.

fix #1899

I'm surprised no-one ever noticed this. #1899 gives a clear repro. And you'll see from [Android's code](https://github.com/doublesymmetry/react-native-track-player/blob/480f64932969545fe38a261fb3867f90f514478c/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt#L417) that it's always worked on that platform.