### PR TITLE
Avoid exiting process when notification closes

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -485,7 +485,6 @@ class MusicService : HeadlessJsTaskService() {
                         }
 
                         stopSelf()
-                        exitProcess(0)
                     }
                 }
             }


### PR DESCRIPTION
On android calling `TrackPlayer.reset()` causes the app to exit. I tracked it down to  `exitProcess(0)` being called when the notification closes: https://github.com/doublesymmetry/react-native-track-player/blob/64d2fb1858a56290d0b4f2339dc6b3e8415b0e5e/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt#L488

This was introduces in the following commit https://github.com/puckey/react-native-track-player/commit/e742959cc1d697d69daeade39830155bce2ccde7 and while I have asked the author @mpivchev for some clarification for the reason for this being added, I have yet to hear back.

For this reason, this pull request will need a bunch of testing as I am unsure on the side effects it might produce. Some cursory testing seems to point to things working though..