### PR TITLE
playWhenReady becomes false when playback stops

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,8 +50,9 @@ repositories {
 
 dependencies {
     implementation 'com.github.doublesymmetry:kotlinaudio:v2.0.0-rc2'
+
     // used when building against local maven
-//    implementation "com.github.doublesymmetry:kotlin-audio:1.2.2"
+    // implementation "com.github.doublesymmetry:kotlin-audio:2.0.0"
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"

--- a/example/src/components/PlayPauseButton.tsx
+++ b/example/src/components/PlayPauseButton.tsx
@@ -16,12 +16,6 @@ export const PlayPauseButton: React.FC<{
     250
   );
 
-  const isErrored = state === State.Error;
-  const isPaused = state === State.Paused;
-  const isStopped = state === State.Stopped;
-  const isEnded = state === State.Ended;
-  const showPause =
-    playWhenReady && !(isErrored || isStopped || isPaused || isEnded);
   const showBuffering = playWhenReady && isLoading;
   return showBuffering ? (
     <View style={styles.statusContainer}>
@@ -29,8 +23,8 @@ export const PlayPauseButton: React.FC<{
     </View>
   ) : (
     <Button
-      title={showPause ? 'Pause' : 'Play'}
-      onPress={showPause ? TrackPlayer.pause : TrackPlayer.play}
+      title={playWhenReady ? 'Pause' : 'Play'}
+      onPress={playWhenReady ? TrackPlayer.pause : TrackPlayer.play}
       type="primary"
       style={styles.playPause}
     />


### PR DESCRIPTION
`playWhenReady` becomes false when playback ends due to `stop()` being called, when a playback error occurs or when the queue ends

See https://github.com/doublesymmetry/KotlinAudio/pull/60

iOS side is still to be done