### PR TITLE
Fix updateOptions

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -12,6 +12,7 @@ import com.doublesymmetry.trackplayer.model.State
 import com.doublesymmetry.trackplayer.model.Track
 import com.doublesymmetry.trackplayer.module.MusicEvents.Companion.EVENT_INTENT
 import com.doublesymmetry.trackplayer.service.MusicService
+import com.doublesymmetry.trackplayer.service.MusicService.PlayerOption
 import com.doublesymmetry.trackplayer.utils.BundleUtils
 import com.doublesymmetry.trackplayer.utils.RejectionException
 import com.facebook.react.bridge.*
@@ -175,16 +176,16 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         // Validate buffer keys.
         val bundledData = Arguments.toBundle(data)
         val minBuffer =
-            bundledData?.getDouble(MusicService.MIN_BUFFER_KEY)?.toMilliseconds()?.toInt()
+            bundledData?.getDouble(PlayerOption.MIN_BUFFER.key)?.toMilliseconds()?.toInt()
                 ?: DEFAULT_MIN_BUFFER_MS
         val maxBuffer =
-            bundledData?.getDouble(MusicService.MAX_BUFFER_KEY)?.toMilliseconds()?.toInt()
+            bundledData?.getDouble(PlayerOption.MAX_BUFFER.key)?.toMilliseconds()?.toInt()
                 ?: DEFAULT_MAX_BUFFER_MS
         val playBuffer =
-            bundledData?.getDouble(MusicService.PLAY_BUFFER_KEY)?.toMilliseconds()?.toInt()
+            bundledData?.getDouble(PlayerOption.PLAY_BUFFER.key)?.toMilliseconds()?.toInt()
                 ?: DEFAULT_BUFFER_FOR_PLAYBACK_MS
         val backBuffer =
-            bundledData?.getDouble(MusicService.BACK_BUFFER_KEY)?.toMilliseconds()?.toInt()
+            bundledData?.getDouble(PlayerOption.BACK_BUFFER.key)?.toMilliseconds()?.toInt()
                 ?: DEFAULT_BACK_BUFFER_DURATION_MS
 
         if (playBuffer < 0) {
@@ -603,16 +604,18 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     @ReactMethod
     fun getProgress(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
-        var bundle = Bundle()
-        bundle.putDouble("duration", musicService.getDurationInSeconds());
-        bundle.putDouble("position", musicService.getPositionInSeconds());
-        bundle.putDouble("buffered", musicService.getBufferedPositionInSeconds());
+
+        var bundle = Bundle().apply {
+            putDouble("duration", musicService.getDurationInSeconds());
+            putDouble("position", musicService.getPositionInSeconds());
+            putDouble("buffered", musicService.getBufferedPositionInSeconds());
+        }
         callback.resolve(Arguments.fromBundle(bundle))
     }
 
     @ReactMethod
     fun getPlaybackState(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
-        callback.resolve(Arguments.fromBundle(musicService.getPlayerStateBundle(musicService.state)))
+        callback.resolve(Arguments.fromBundle(musicService.getPlaybackStateBundle(musicService.state)))
     }
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/utils/BundleUtils.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/utils/BundleUtils.kt
@@ -53,26 +53,6 @@ object BundleUtils {
         }
     }
 
-    fun getIcon(context: Context, options: Bundle, propertyName: String, defaultIcon: Int): Int {
-        if (!options.containsKey(propertyName)) return defaultIcon
-
-        val bundle = options.getBundle(propertyName) ?: return defaultIcon
-
-        val helper = ResourceDrawableIdHelper.getInstance()
-        val icon = helper.getResourceDrawableId(context, bundle.getString("uri"))
-        return if (icon == 0) defaultIcon else icon
-    }
-
-    fun getIconOrNull(context: Context, options: Bundle, propertyName: String): Int? {
-        if (!options.containsKey(propertyName)) return null
-
-        val bundle = options.getBundle(propertyName) ?: return null
-
-        val helper = ResourceDrawableIdHelper.getInstance()
-        val icon = helper.getResourceDrawableId(context, bundle.getString("uri"))
-        return if (icon == 0) null else icon
-    }
-
     fun getRating(data: Bundle?, key: String?, ratingType: Int): RatingCompat? {
         return if (!data!!.containsKey(key) || ratingType == RatingCompat.RATING_NONE) {
             RatingCompat.newUnratedRating(ratingType)


### PR DESCRIPTION
__iOS__

not done yet

__Android__

(yet to be tested)

MusicService#updateOptions:
- merge options in order to avoid reverting previous options
- check whether updates are necessary before updating notification / progress update job etc
- extract updateProgressUpdate and updateNotification methods because they are quite complex
- inline getIcon helper and merge with getIconOrNull using default value for defaultIcon parameter

chores:
- rename `MusicService#getPlayerStateBundle` to `MusicService#getPlaybackStateBundle` and  remove unnecessary parameter
- extract const vals into enums grouped by topic
- inline const vals that are only used in one place, since there were already a bunch of inlined string keys for bundles.. and the code becomes more legible this way
- use Bundle().apply where possible
- inline MusicService.isCompact
- move DEFAULT_JUMP_INTERVAL value closer to where it is actually being used
