### PR TITLE
feat: Equalizer

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -45,6 +45,7 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val PLAYBACK_METADATA = "playback-metadata-received"
         const val PLAYBACK_PROGRESS_UPDATED = "playback-progress-updated"
         const val PLAYBACK_ERROR = "playback-error"
+        const val EQUALIZER_CHANGED = "equalizer-changed"
 
         const val EVENT_INTENT = "com.doublesymmetry.trackplayer.event"
     }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -615,4 +615,35 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         if (verifyServiceBoundOrReject(callback)) return@launch
         callback.resolve(Arguments.fromBundle(musicService.getPlayerStateBundle(musicService.state)))
     }
+
+    @ReactMethod
+    fun getEqualizerSettings(callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        callback.resolve(Arguments.fromBundle(musicService.getEqualizerSettings()))
+    }
+
+    @ReactMethod
+    fun setEqualizerEnabled(enabled: Boolean, callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        musicService.setEqualizerEnabled(enabled)
+        callback.resolve(null)
+    }
+
+    @ReactMethod
+    fun setEqualizerPreset(preset: String, callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        musicService.setEqualizerPreset(preset)
+        callback.resolve(null)
+    }
+
+    @ReactMethod
+    fun setEqualizerLevels(data: ReadableArray, callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        val levels = ShortArray(data.size())
+        for (i in 0 until data.size()) {
+            levels[i] = data.getInt(i).toShort()
+        }
+        musicService.setEqualizerLevels(levels)
+        callback.resolve(null)
+    }
 }

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -1,4 +1,6 @@
 export enum Event {
+  /** Fired when the equalizer settings have changed. */
+  EqualizerChanged = 'equalizer-changed',
   /** Fired when the state of the player changes. */
   PlaybackState = 'playback-state',
   /** Fired when a playback error occurs. */

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useActiveTrack';
-export * from './usePlayWhenReady';
+export * from './useEqualizer';
 export * from './usePlaybackState';
+export * from './usePlayWhenReady';
 export * from './useProgress';
 export * from './useTrackPlayerEvents';

--- a/src/hooks/useEqualizer.ts
+++ b/src/hooks/useEqualizer.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { Event } from '../constants';
+import { EqualizerSettings } from '../interfaces';
+import { addEventListener, getEqualizerSettings } from '../trackPlayer';
+
+export const useEqualizer = (): EqualizerSettings | undefined => {
+  const [equalizerSettings, setEqualizerSettings] = useState<
+    EqualizerSettings | undefined
+  >();
+  useEffect(() => {
+    let mounted = true;
+
+    getEqualizerSettings()
+      .then((fetchedEqualizerSettings) => {
+        if (!mounted) return;
+        // Only set  if it wasn't already set by the listener below:
+        setEqualizerSettings((currentEqualizerSettings) =>
+          currentEqualizerSettings ? currentEqualizerSettings : fetchedEqualizerSettings
+        );
+      })
+      .catch(() => {
+        /** only throws while you haven't yet setup, ignore failure. */
+      });
+
+    const sub = addEventListener(Event.EqualizerChanged, (equalizerSettings) => {
+      setEqualizerSettings(equalizerSettings);
+    });
+
+    return () => {
+      mounted = false;
+      sub.remove();
+    };
+  }, []);
+
+  return equalizerSettings;
+};

--- a/src/interfaces/EqualizerSettings.ts
+++ b/src/interfaces/EqualizerSettings.ts
@@ -1,0 +1,12 @@
+
+
+export type EqualizerSettings = {
+  activePreset?: string;
+  bandCount: number;
+  bandLevels: number[];
+  centerBandFrequencies: number[];
+  enabled: boolean;
+  lowerBandLevelLimit: number;
+  presets: string[];
+  upperBandLevelLimit: number;
+}

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -1,23 +1,25 @@
 import { Event } from '../../constants';
 
+import { EqualizerSettings } from '../EqualizerSettings';
 import type { PlaybackState } from '../PlaybackState';
-import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
-import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
-import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
 import type { PlaybackActiveTrackChangedEvent } from './PlaybackActiveTrackChangedEvent';
+import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
 import type { PlaybackMetadataReceivedEvent } from './PlaybackMetadataReceivedEvent';
 import type { PlaybackPlayWhenReadyChangedEvent } from './PlaybackPlayWhenReadyChangedEvent';
 import type { PlaybackProgressUpdatedEvent } from './PlaybackProgressUpdatedEvent';
+import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
+import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
+import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
 import type { RemotePlayIdEvent } from './RemotePlayIdEvent';
 import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
-import type { RemoteSkipEvent } from './RemoteSkipEvent';
-import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
-import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
-import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteSkipEvent } from './RemoteSkipEvent';
 
 export interface EventPayloadByEvent {
+  [Event.EqualizerChanged]: EqualizerSettings;
   [Event.PlaybackState]: PlaybackState;
   [Event.PlaybackError]: PlaybackErrorEvent;
   [Event.PlaybackQueueEnded]: PlaybackQueueEndedEvent;

--- a/src/interfaces/events/EventsPayloadByEvent.ts
+++ b/src/interfaces/events/EventsPayloadByEvent.ts
@@ -1,23 +1,25 @@
 import { Event } from '../../constants';
 
+import { EqualizerSettings } from '../EqualizerSettings';
 import type { PlaybackState } from '../PlaybackState';
-import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
-import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
-import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
 import type { PlaybackActiveTrackChangedEvent } from './PlaybackActiveTrackChangedEvent';
+import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
 import type { PlaybackMetadataReceivedEvent } from './PlaybackMetadataReceivedEvent';
 import type { PlaybackPlayWhenReadyChangedEvent } from './PlaybackPlayWhenReadyChangedEvent';
 import type { PlaybackProgressUpdatedEvent } from './PlaybackProgressUpdatedEvent';
+import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
+import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
+import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
 import type { RemotePlayIdEvent } from './RemotePlayIdEvent';
 import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
-import type { RemoteSkipEvent } from './RemoteSkipEvent';
-import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
-import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
-import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteSkipEvent } from './RemoteSkipEvent';
 
 export interface EventsPayloadByEvent {
+  [Event.EqualizerChanged]: EqualizerSettings & { type: Event.EqualizerChanged };
   [Event.PlaybackState]: PlaybackState & { type: Event.PlaybackState };
   [Event.PlaybackError]: PlaybackErrorEvent & { type: Event.PlaybackError };
   [Event.PlaybackQueueEnded]: PlaybackQueueEndedEvent & {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,4 +1,6 @@
 export * from './AndroidOptions';
+export * from './EqualizerSettings';
+export * from './events';
 export * from './FeedbackOptions';
 export * from './MetadataOptions';
 export * from './NowPlayingMetadata';
@@ -10,4 +12,3 @@ export * from './ServiceHandler';
 export * from './Track';
 export * from './TrackMetadataBase';
 export * from './UpdateOptions';
-export * from './events';

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -3,13 +3,14 @@ import {
   DeviceEventEmitter,
   NativeEventEmitter,
   NativeModules,
-  Platform,
+  Platform
 } from 'react-native';
 // @ts-expect-error because resolveAssetSource is untyped
 import { default as resolveAssetSource } from 'react-native/Libraries/Image/resolveAssetSource';
 
 import { Event, RepeatMode, State } from './constants';
 import type {
+  EqualizerSettings,
   EventPayloadByEvent,
   NowPlayingMetadata,
   PlaybackState,
@@ -18,7 +19,7 @@ import type {
   ServiceHandler,
   Track,
   TrackMetadataBase,
-  UpdateOptions,
+  UpdateOptions
 } from './interfaces';
 
 const { TrackPlayerModule: TrackPlayer } = NativeModules;
@@ -508,4 +509,20 @@ export async function getRepeatMode(): Promise<RepeatMode> {
  */
 export async function retry() {
   return TrackPlayer.retry();
+}
+
+export async function getEqualizerSettings(): Promise<EqualizerSettings> {
+  return TrackPlayer.getEqualizerSettings();
+}
+
+export async function setEqualizerEnabled(enabled: boolean): Promise<void> {
+  return TrackPlayer.setEqualizerEnabled(enabled);
+}
+
+export async function setEqualizerPreset(preset: string): Promise<void> {
+  return TrackPlayer.setEqualizerPreset(preset);
+}
+
+export async function setEqualizerLevels(levels: number[]): Promise<void> {
+  return TrackPlayer.setEqualizerLevels(levels);
 }


### PR DESCRIPTION
See https://github.com/doublesymmetry/react-native-track-player/issues/1950

Implements equalizer functionality for Android – relies on the following pr to be merged: https://github.com/doublesymmetry/KotlinAudio/pull/68

- `TrackPlayer.getEqualizerSettings(): Promise<EqualizerSettings>`
- `TrackPlayer.setEqualizerEnabled(enabled: boolean): Promise<void>`
- `TrackPlayer.setEqualizerPreset(preset: string): Promise<void>`
- `TrackPlayer.setEqualizerLevels(levels: number[]): Promise<void>`
- `useEqualizer()` hook which returns updated `EqualizerSettings` whenever any of its properties change

```ts
type EqualizerSettings = {
  activePreset?: string;
  bandCount: number;
  bandLevels: number[];
  centerBandFrequencies: number[];
  enabled: boolean;
  lowerBandLevelLimit: number;
  presets: string[];
  upperBandLevelLimit: number;
}
```