### PR TITLE
Allows the granularity to be less than one second. Player updates wou…

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -337,7 +337,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
     private func configureProgressUpdateEvent(interval: Double) {
         shouldEmitProgressEvent = interval > 0
         self.player.timeEventFrequency = shouldEmitProgressEvent
-            ? .custom(time: CMTime(seconds: interval, preferredTimescale: 1000))
+            ? .custom(time: CMTime(seconds: interval, preferredTimescale: Int32(NSEC_PER_SEC)))
             : .everySecond
     }
 


### PR DESCRIPTION
…ld be limited to a minimum value of one second on iOS if this is not done.