### PR TITLE
docs(expo): Remove misleading documentation about Expo support 

### DIFF
--- a/docs/docs/basics/installation.mdx
+++ b/docs/docs/basics/installation.mdx
@@ -62,4 +62,13 @@ cd ios && pod install
 
 ## Expo
 
-Unfortunately, we do not support Expo at this time.
+You can now use React Native Track Player with Expo. 
+
+Please be aware that while many people are using React Native Track Player with Expo successfully, the current maintainers of this project do not use Expo and their ability to resolve issues involving Expo is limited.
+
+To get started, create a [custom development client](https://docs.expo.dev/clients/getting-started/) for your Expo app and then install React Native Track Player.
+
+Here is the configuration required for audio playback in background:
+
+- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background-ios)
+- [Android: Stop playback when the app is closed](./background-mode.md/#android)


### PR DESCRIPTION
It seems that "none of the maintainers use Expo and we don't really officially support it given the lack of expertise in it on the team." https://github.com/doublesymmetry/react-native-track-player/issues/1963#issuecomment-1475198626

I would have saved a lot of time and effort if the docs had not clearly stated that Expo is supported when it isn't. Hopefully this change will save others from the same wasted effort.