### PR TITLE
chore(example): update now playing with received playback metadata

### DIFF
--- a/example/src/services/PlaybackService.ts
+++ b/example/src/services/PlaybackService.ts
@@ -55,4 +55,16 @@ export async function PlaybackService() {
   TrackPlayer.addEventListener(Event.PlaybackState, (event) => {
     console.log('Event.PlaybackState', event);
   });
+
+  TrackPlayer.addEventListener(
+    Event.PlaybackMetadataReceived,
+    async ({ title, artist }) => {
+      const activeTrack = await TrackPlayer.getActiveTrack();
+      TrackPlayer.updateNowPlayingMetadata({
+        artist: [title, artist].filter(Boolean).join(' - '),
+        title: activeTrack?.title,
+        artwork: activeTrack?.artwork,
+      });
+    }
+  );
 }


### PR DESCRIPTION
Shows the currently playing track and artist in the example app's notification when you are on the jazz radio live stream.