### PR TITLE
feat: sleep timer

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/addons/SleepTimer.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/addons/SleepTimer.kt
@@ -1,0 +1,46 @@
+package com.doublesymmetry.trackplayer.addons
+
+import android.os.Handler
+import android.os.Looper
+import kotlinx.coroutines.*
+
+open class SleepTimer {
+    var time: Double? = null
+    private var runnable: Runnable? = null
+    private val handler = Handler(Looper.getMainLooper())
+
+    val isRunning: Boolean
+        get() = time != null
+
+    fun sleepAfter(seconds: Double) {
+        stopTimer()
+        val runnable = Runnable {
+            complete()
+        }
+        this.runnable = runnable
+        Handler(Looper.getMainLooper()).postDelayed(runnable, seconds.toLong() * 1000)
+        time = System.currentTimeMillis() + (seconds * 1000)
+    }
+
+    fun clear(): Boolean {
+        val wasRunning = isRunning
+        stopTimer()
+        time = null
+        return wasRunning
+    }
+
+    open fun onComplete() {
+        // noop
+    }
+
+    private fun complete() {
+        if (!isRunning) return;
+        clear()
+        onComplete()
+    }
+
+    private fun stopTimer() {
+        runnable?.let { handler.removeCallbacks(it) }
+        runnable = null
+    }
+}

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -46,6 +46,9 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val PLAYBACK_PROGRESS_UPDATED = "playback-progress-updated"
         const val PLAYBACK_ERROR = "playback-error"
 
+        const val SLEEP_TIMER_CHANGED = "sleep-timer-changed"
+        const val SLEEP_TIMER_COMPLETE = "sleep-timer-complete"
+
         const val EVENT_INTENT = "com.doublesymmetry.trackplayer.event"
     }
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -615,4 +615,33 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         if (verifyServiceBoundOrReject(callback)) return@launch
         callback.resolve(Arguments.fromBundle(musicService.getPlayerStateBundle(musicService.state)))
     }
+
+    @ReactMethod
+    fun sleepWhenActiveTrackReachesEnd(callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        musicService.sleepWhenActiveTrackReachesEnd()
+        callback.resolve(null)
+    }
+
+    @ReactMethod
+    fun setSleepTimer(seconds: Double, callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        callback.resolve(Arguments.fromBundle(musicService.setSleepTimer(seconds)))
+    }
+
+    @ReactMethod
+    fun clearSleepTimer(callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        musicService.clearSleepTimer()
+        callback.resolve(null)
+    }
+
+    @ReactMethod
+    fun getSleepTimer(callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+        val result = musicService.getSleepTimer()
+        callback.resolve(
+            if (result == null) null else Arguments.fromBundle(result)
+        )
+    }
 }

--- a/example/src/services/PlaybackService.ts
+++ b/example/src/services/PlaybackService.ts
@@ -55,4 +55,12 @@ export async function PlaybackService() {
   TrackPlayer.addEventListener(Event.PlaybackState, (event) => {
     console.log('Event.PlaybackState', event);
   });
+
+  TrackPlayer.addEventListener(Event.SleepTimerChanged, (event) => {
+    console.log('Event.SleepTimerChanged', JSON.stringify(event, null, 2));
+  });
+
+  TrackPlayer.addEventListener(Event.SleepTimerComplete, () => {
+    console.log('Event.SleepTimerComplete');
+  });
 }

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -37,6 +37,8 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         player.event.currentItem.addListener(self, handleAudioPlayerCurrentItemChange)
         player.event.secondElapse.addListener(self, handleAudioPlayerSecondElapse)
         player.event.playWhenReadyChange.addListener(self, handlePlayWhenReadyChange)
+        player.event.sleepTimerChange.addListener(self, handleSleepTimerChange)
+        player.event.sleepTimerComplete.addListener(self, handleSleepTimerComplete)
     }
 
     deinit {
@@ -750,6 +752,33 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         Metadata.update(for: player, with: metadata)
         resolve(NSNull())
     }
+
+    @objc(getSleepTimerProgress:rejecter:)
+    public func getSleepTimer(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (rejectWhenNotInitialized(reject: reject)) { return }
+        resolve(player.getSleepTimer())
+    }
+
+    @objc(setSleepTimer:resolver:rejecter:)
+    public func setSleepTimer(seconds: Double, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (rejectWhenNotInitialized(reject: reject)) { return }
+        player.setSleepTimer(time: seconds)
+        resolve(player.getSleepTimer())
+    }
+
+    @objc(sleepWhenActiveTrackReachesEnd:rejecter:)
+    public func sleepWhenActiveTrackReachesEnd(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (rejectWhenNotInitialized(reject: reject)) { return }
+        player.sleepWhenCurrentItemReachesEnd()
+        resolve(player.getSleepTimer())
+    }
+
+    @objc(clearSleepTimer:rejecter:)
+    public func clearSleepTimer(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (rejectWhenNotInitialized(reject: reject)) { return }
+        player.clearSleepTimer()
+        resolve(NSNull())
+    }
     
     private func getPlaybackStateErrorKeyValues() -> Dictionary<String, Any> {
         switch player.playbackError {
@@ -957,5 +986,16 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
                 "playWhenReady": playWhenReady
             ]
         )
+    }
+    
+    func handleSleepTimerChange(sleepTimer: [String : Any]?) {
+        emit(
+            event: EventType.SleepTimerChanged,
+            body: sleepTimer
+        )
+    }
+
+    func handleSleepTimerComplete() {
+        emit(event: EventType.SleepTimerComplete, body: nil)
     }
 }

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -113,4 +113,12 @@ export enum Event {
    * See https://react-native-track-player.js.org/docs/api/events#remoteskip
    **/
   RemoteSkip = 'remote-skip',
+  /**
+   * Fired when sleep timer has changed.
+   **/
+  SleepTimerChanged = 'sleep-timer-changed',
+  /**
+   * Fired when sleep timer has completed.
+   **/
+   SleepTimerComplete = 'sleep-timer-complete'
 }

--- a/src/hooks/useSleepTimer.ts
+++ b/src/hooks/useSleepTimer.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { Event } from "../constants";
+import { getSleepTimer } from '../trackPlayer';
+import { useAppIsInBackground } from "./useAppIsInBackground";
+import { useTrackPlayerEvents } from "./useTrackPlayerEvents";
+
+/**
+ * Hook that returns the current sleep timer state and time left.
+ *
+ * Note that time left is not updated when the app is in the background.
+ *
+ * @param updateInterval - ms interval at which the time left is updated.
+ * Defaults to 60000 (1 minute).
+ */
+export function useSleepTimer(updateInterval = 60000) {
+  // Avoid updating time left when the app is in the background
+  const inactive = useAppIsInBackground();
+  const [state, setState] = useState<
+    | { time: number; secondsLeft: number }
+    | { sleepWhenPlayedToEnd: boolean }
+    | undefined
+  >(undefined);
+
+  const time = state && 'time' in state ? state.time : undefined;
+
+  const addSecondsLeft = (
+    state:
+      | { time: number; secondsLeft?: number }
+      | { sleepWhenPlayedToEnd: boolean }
+      | undefined
+  ) =>
+    state
+      ? 'time' in state
+        ? {
+            ...state,
+            secondsLeft: Math.max(
+              0,
+              Math.round((state.time - Date.now()) / 1000)
+            ),
+          }
+        : state
+      : undefined;
+
+  useTrackPlayerEvents([Event.SleepTimerChanged], (event) => {
+    setState(addSecondsLeft(event));
+  });
+
+  useEffect(() => {
+    let unmounted = false;
+    getSleepTimer().then((state) => {
+      if (unmounted) return;
+      setState(addSecondsLeft(state ?? undefined));
+    });
+    return () => {
+      unmounted = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (inactive || time === undefined) return;
+    const update = () => {
+      setState((sleepTimer) => {
+        const result = addSecondsLeft(sleepTimer);
+        if (result && 'secondsLeft' in result && result.secondsLeft === 0) {
+          clear();
+        }
+        return result;
+      });
+    };
+
+    // In order to make time update reaching 0 sync with firing of completion,
+    // first wait for the next interval to start before starting update loop
+    let timeoutId = setTimeout(() => {
+      update();
+      timeoutId = setInterval(update, updateInterval);
+    }, updateInterval - (time % updateInterval));
+    const clear = () => clearInterval(timeoutId);
+    update();
+    return clear;
+  }, [inactive, time, updateInterval]);
+
+  return state;
+}

--- a/src/interfaces/SleepTimer.ts
+++ b/src/interfaces/SleepTimer.ts
@@ -1,0 +1,6 @@
+export type SleepTimer =
+| { time: number }
+| { sleepWhenPlayedToEnd: boolean }
+| null
+
+export type SleepTimerChangedEvent = SleepTimer;

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -1,21 +1,22 @@
 import { Event } from '../../constants';
 
 import type { PlaybackState } from '../PlaybackState';
-import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
-import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
-import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import { SleepTimerChangedEvent } from '../SleepTimer';
 import type { PlaybackActiveTrackChangedEvent } from './PlaybackActiveTrackChangedEvent';
+import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
 import type { PlaybackMetadataReceivedEvent } from './PlaybackMetadataReceivedEvent';
 import type { PlaybackPlayWhenReadyChangedEvent } from './PlaybackPlayWhenReadyChangedEvent';
 import type { PlaybackProgressUpdatedEvent } from './PlaybackProgressUpdatedEvent';
+import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
+import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
+import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
 import type { RemotePlayIdEvent } from './RemotePlayIdEvent';
 import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
-import type { RemoteSkipEvent } from './RemoteSkipEvent';
-import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
-import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
-import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteSkipEvent } from './RemoteSkipEvent';
 
 export interface EventPayloadByEvent {
   [Event.PlaybackState]: PlaybackState;
@@ -42,4 +43,6 @@ export interface EventPayloadByEvent {
   [Event.RemoteLike]: never;
   [Event.RemoteDislike]: never;
   [Event.RemoteBookmark]: never;
+  [Event.SleepTimerChanged]: SleepTimerChangedEvent;
+  [Event.SleepTimerComplete]: never;
 }

--- a/src/interfaces/events/EventsPayloadByEvent.ts
+++ b/src/interfaces/events/EventsPayloadByEvent.ts
@@ -1,21 +1,22 @@
 import { Event } from '../../constants';
 
 import type { PlaybackState } from '../PlaybackState';
-import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
-import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
-import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import { SleepTimerChangedEvent } from '../SleepTimer';
 import type { PlaybackActiveTrackChangedEvent } from './PlaybackActiveTrackChangedEvent';
+import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
 import type { PlaybackMetadataReceivedEvent } from './PlaybackMetadataReceivedEvent';
 import type { PlaybackPlayWhenReadyChangedEvent } from './PlaybackPlayWhenReadyChangedEvent';
 import type { PlaybackProgressUpdatedEvent } from './PlaybackProgressUpdatedEvent';
+import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
+import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
+import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
 import type { RemotePlayIdEvent } from './RemotePlayIdEvent';
 import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
-import type { RemoteSkipEvent } from './RemoteSkipEvent';
-import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
-import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
-import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteSkipEvent } from './RemoteSkipEvent';
 
 export interface EventsPayloadByEvent {
   [Event.PlaybackState]: PlaybackState & { type: Event.PlaybackState };
@@ -62,4 +63,8 @@ export interface EventsPayloadByEvent {
   [Event.RemoteLike]: { type: Event.RemoteLike };
   [Event.RemoteDislike]: { type: Event.RemoteDislike };
   [Event.RemoteBookmark]: { type: Event.RemoteBookmark };
+  [Event.SleepTimerChanged]: SleepTimerChangedEvent & {
+    type: Event.SleepTimerChanged;
+  };
+  [Event.SleepTimerComplete]: { type: Event.SleepTimerComplete; };
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './AndroidOptions';
+export * from './events';
 export * from './FeedbackOptions';
 export * from './MetadataOptions';
 export * from './NowPlayingMetadata';
@@ -7,7 +8,7 @@ export * from './PlayerOptions';
 export * from './Progress';
 export * from './ResourceObject';
 export * from './ServiceHandler';
+export * from './SleepTimer';
 export * from './Track';
 export * from './TrackMetadataBase';
 export * from './UpdateOptions';
-export * from './events';

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -16,6 +16,7 @@ import type {
   PlayerOptions,
   Progress,
   ServiceHandler,
+  SleepTimer,
   Track,
   TrackMetadataBase,
   UpdateOptions,
@@ -501,6 +502,45 @@ export async function getPlaybackState(): Promise<PlaybackState> {
  */
 export async function getRepeatMode(): Promise<RepeatMode> {
   return TrackPlayer.getRepeatMode();
+}
+
+/**
+ * Sets a sleep timer to fire after a specified amount of seconds.
+ *
+ * Note that if a sleep timer was set previously, it will be replaced by the
+ * new one.
+ */
+export async function setSleepTimer(seconds: number): Promise<SleepTimer> {
+  if (seconds <= 0) {
+    throw new Error('The sleep timer must be greater than 0.');
+  }
+  return TrackPlayer.setSleepTimer(seconds);
+}
+
+/**
+ * Pauses playback when the active track ends. Note that this will override any
+ * sleep timer that was set previously. To clear call `TrackPlayer.clearSleepTimer()`.
+ */
+export async function sleepWhenActiveTrackReachesEnd(): Promise<void> {
+  return TrackPlayer.sleepWhenActiveTrackReachesEnd();
+}
+
+/**
+ * Gets information on the current sleep timer. Returns `null` if there is no
+ * sleep timer set.
+ */
+export async function getSleepTimer(): Promise<SleepTimer> {
+  return (await TrackPlayer.getSleepTimer()) ?? undefined;
+}
+
+/**
+ * Clears the sleep timer if it was set previously.
+ *
+ * Note that it is not necessary to clear the sleep timer before setting a new
+ * one.
+ */
+export async function clearSleepTimer(): Promise<void> {
+  return TrackPlayer.clearSleepTimer();
 }
 
 /**


### PR DESCRIPTION
- ios implementation depends on https://github.com/doublesymmetry/SwiftAudioEx/pull/47
- android implementation
- `TrackPlayer.setSleepTimer(seconds)`
- `TrackPlayer.sleepWhenActiveTrackReachesEnd()`
- `TrackPlayer.getSleepTimer()`
- `TrackPlayer.clearSleepTimer()`
- `sleep-timer-changed` event
- `sleep-timer-complete` event
- `useSleepTimer()` hook