### PR TITLE
docs: update expo url

### DIFF
--- a/docs/docs/basics/installation.mdx
+++ b/docs/docs/basics/installation.mdx
@@ -70,5 +70,5 @@ To get started, create a [custom development client](https://docs.expo.dev/clien
 
 Here is the configuration required for audio playback in background:
 
-- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background-ios)
+- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background)
 - [Android: Stop playback when the app is closed](./background-mode.md/#android)

--- a/docs/versioned_docs/version-2.1/basics/installation.mdx
+++ b/docs/versioned_docs/version-2.1/basics/installation.mdx
@@ -64,5 +64,5 @@ Start by creating a [custom development client](https://docs.expo.dev/clients/ge
 
 Here is the configuration required for audio playback in background:
 
-- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background-ios)
+- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background)
 - [Android: Stop playback when the app is closed](./background-mode.md/#android)

--- a/docs/versioned_docs/version-3.1/basics/installation.mdx
+++ b/docs/versioned_docs/version-3.1/basics/installation.mdx
@@ -68,5 +68,5 @@ Start by creating a [custom development client](https://docs.expo.dev/clients/ge
 
 Here is the configuration required for audio playback in background:
 
-- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background-ios)
+- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background)
 - [Android: Stop playback when the app is closed](./background-mode.md/#android)

--- a/docs/versioned_docs/version-3.2/basics/installation.mdx
+++ b/docs/versioned_docs/version-3.2/basics/installation.mdx
@@ -68,5 +68,5 @@ Start by creating a [custom development client](https://docs.expo.dev/clients/ge
 
 Here is the configuration required for audio playback in background:
 
-- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background-ios)
+- [iOS: Enable audio playback in background via your app.json](https://docs.expo.dev/versions/latest/sdk/audio/#playing-or-recording-audio-in-background)
 - [Android: Stop playback when the app is closed](./background-mode.md/#android)


### PR DESCRIPTION
It seems that expo document changed page's DOM id, so RNTP's link does not work for correct position.

I just fixed page hash.