### PR TITLE
Update getting-started.md to include necessary code for implementing the trackplayer

### DIFF
--- a/docs/docs/basics/getting-started.md
+++ b/docs/docs/basics/getting-started.md
@@ -19,6 +19,8 @@ TrackPlayer.registerPlaybackService(() => require('./service'));
 
 ```
 
+Then create the file `service.js`
+
 ```ts
 // service.js
 module.exports = async function() {
@@ -31,7 +33,14 @@ Then, you need to set up the player. This usually takes less than a second:
 ```ts
 import TrackPlayer from 'react-native-track-player';
 
-await TrackPlayer.setupPlayer()
+async function setupPlayer() {
+  await TrackPlayer.setupPlayer();
+  // The player is ready to be used
+}
+
+function App(): JSX.Element {
+  await setupPlayer();
+}
 // The player is ready to be used
 ```
 

--- a/docs/docs/basics/getting-started.md
+++ b/docs/docs/basics/getting-started.md
@@ -7,8 +7,16 @@ sidebar_position: 2
 ## Starting off
 First, you need to register a [playback service](./playback-service.md) right after registering the main component of your app (typically in your `index.js` file at the root of your project):
 ```ts
-// AppRegistry.registerComponent(...);
+import {AppRegistry} from 'react-native';
+import TrackPlayer from 'react-native-track-player';
+
+import App from './App';
+import {PlaybackService} from './src/services';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);
 TrackPlayer.registerPlaybackService(() => require('./service'));
+
 ```
 
 ```ts


### PR DESCRIPTION
The way the documentation is set up currently seems to imply you should comment out the `import {AppRegistry} from 'react-native';` line. It also doesn't include the necessary dependencies to implement the shown `TrackPlayer.registerPlaybackService(() => require('./service'));` which are:

```
import TrackPlayer from 'react-native-track-player';
import {PlaybackService} from './src/services';
```