### PR TITLE
docs(player): fix references to PlayerOptions and UpdateOptions

### DIFF
--- a/docs/docs/api/functions/player.md
+++ b/docs/docs/api/functions/player.md
@@ -2,7 +2,7 @@
 
 ## `setupPlayer(options)`
 
-Accepts a [`PlayerOptions`](../objects/metadata-options.md) object.
+Accepts a [`PlayerOptions`](../objects/player-options.md) object.
 
 ## `updateOptions(options)`
 

--- a/docs/docs/api/functions/player.md
+++ b/docs/docs/api/functions/player.md
@@ -6,7 +6,7 @@ Accepts a [`PlayerOptions`](../objects/metadata-options.md) object.
 
 ## `updateOptions(options)`
 
-Accepts a [`MetadataOptions`](../objects/metadata-options.md) object. Updates
+Accepts a [`UpdateOptions`](../objects/update-options.md) object. Updates
 the configuration for the components.
 
 


### PR DESCRIPTION
1. The documentation for the `updateOptions` function was pointing to the deprecated type `MetadataOptions`. This fixes the reference to point to the `UpdateOptions` type.
2. The documentation for the `setupPlayer` function had the correct name, but the link was pointing to the wrong place. This fixes the link to point to `PlayerOptions`.