### PR TITLE
fix(android): Allow precise seeking on Android

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -356,7 +356,7 @@ class MusicService : HeadlessJsTaskService() {
 
     @MainThread
     fun seekTo(seconds: Float) {
-        player.seek((seconds.toLong()), TimeUnit.SECONDS)
+        player.seek((seconds * 1000).toLong(), TimeUnit.MILLISECONDS)
     }
 
     @MainThread


### PR DESCRIPTION
Converting to Long eliminates the decimal values.

For example, i made an app that replicates the SoundCloud waveform and whenever i seek the track, the waveform would sometimes go backwards from the position because there's no decimal values to seek precisely.

This PR will allow precise seeking.

i checked on iOS and it seem already able to seek precisely out of the box.