### PR TITLE
fix(Android): improved foreground service handling

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <application>
 
         <!-- The main service, handles playback, playlists and media buttons -->


### PR DESCRIPTION
Additional improvements on foreground service handling. Fixes https://github.com/doublesymmetry/react-native-track-player/issues/1986

Inspired by still seeing crashes on a client project and taking inspiration from other open source projects, we found that continuing to call `startForeground(...)` when not in the foreground causes the `ForegroundServiceStartNotAllowedException` to be thrown after a while.

Our findings are that once the initial first call to `startForeground()` succeeds and we are in the background, we are good to go. The documentation from Google is a bit unclear (to say the least) on this.

Inspiration from VLC: 
https://code.videolan.org/videolan/vlc-android/-/blob/master/application/vlc-android/src/org/videolan/vlc/PlaybackService.kt#L762
https://code.videolan.org/videolan/vlc-android/-/blob/master/application/vlc-android/src/org/videolan/vlc/PlaybackService.kt#L917

PocketCasts:
https://github.com/Automattic/pocket-casts-android/blob/ee8da0c095560ef64a82d3a31464491b8d713104/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt#L249-L261