### PR TITLE
fix(Android): improved foreground service handling

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <application>
 
         <!-- The main service, handles playback, playlists and media buttons -->

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -46,6 +46,9 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val PLAYBACK_PROGRESS_UPDATED = "playback-progress-updated"
         const val PLAYBACK_ERROR = "playback-error"
 
+        // Other
+        const val FOREGROUND_SERVICE_START_NOT_ALLOWED = "android-foreground-service-start-not-allowed"
+
         const val EVENT_INTENT = "com.doublesymmetry.trackplayer.event"
     }
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -47,7 +47,7 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val PLAYBACK_ERROR = "playback-error"
 
         // Other
-        const val FOREGROUND_SERVICE_START_NOT_ALLOWED = "android-foreground-service-start-not-allowed"
+        const val PLAYER_ERROR = "player-error"
 
         const val EVENT_INTENT = "com.doublesymmetry.trackplayer.event"
     }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -532,15 +532,18 @@ class MusicService : HeadlessJsTaskService() {
                                     startForeground(notificationId!!, notification)
                                 }
                             }
-                        } catch (e: Exception) {
+                        } catch (error: Exception) {
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-                                e is ForegroundServiceStartNotAllowedException
+                                error is ForegroundServiceStartNotAllowedException
                             ) {
                                 Timber.e(
-                                    "ForegroundServiceStartNotAllowedException: startForeground(it.notificationId, it.notification) called from background...",
-                                    e
+                                    "ForegroundServiceStartNotAllowedException: App tried to start a foreground Service when it was not allowed to do so.",
+                                    error
                                 )
-                                emit(MusicEvents.FOREGROUND_SERVICE_START_NOT_ALLOWED);
+                                emit(MusicEvents.PLAYER_ERROR, Bundle().apply {
+                                    putString("message", error.message)
+                                    putString("code", "android-foreground-service-start-not-allowed")
+                                });
                             }
                         }
                     }

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -1,4 +1,6 @@
 export enum Event {
+  ForegroundServiceStartNotAllowed = 'android-foreground-service-start-not-allowed',
+
   /** Fired when the state of the player changes. */
   PlaybackState = 'playback-state',
   /** Fired when a playback error occurs. */

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -1,5 +1,5 @@
 export enum Event {
-  ForegroundServiceStartNotAllowed = 'android-foreground-service-start-not-allowed',
+  PlayerError = 'player-error',
 
   /** Fired when the state of the player changes. */
   PlaybackState = 'playback-state',

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -1,23 +1,25 @@
 import { Event } from '../../constants';
 
 import type { PlaybackState } from '../PlaybackState';
-import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
-import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
-import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
 import type { PlaybackActiveTrackChangedEvent } from './PlaybackActiveTrackChangedEvent';
+import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
 import type { PlaybackMetadataReceivedEvent } from './PlaybackMetadataReceivedEvent';
 import type { PlaybackPlayWhenReadyChangedEvent } from './PlaybackPlayWhenReadyChangedEvent';
 import type { PlaybackProgressUpdatedEvent } from './PlaybackProgressUpdatedEvent';
+import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
+import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import { PlayerErrorEvent } from './PlayerErrorEvent';
+import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
+import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
 import type { RemotePlayIdEvent } from './RemotePlayIdEvent';
 import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
-import type { RemoteSkipEvent } from './RemoteSkipEvent';
-import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
-import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
-import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteSkipEvent } from './RemoteSkipEvent';
 
 export interface EventPayloadByEvent {
+  [Event.PlayerError]: PlayerErrorEvent;
   [Event.PlaybackState]: PlaybackState;
   [Event.PlaybackError]: PlaybackErrorEvent;
   [Event.PlaybackQueueEnded]: PlaybackQueueEndedEvent;

--- a/src/interfaces/events/EventsPayloadByEvent.ts
+++ b/src/interfaces/events/EventsPayloadByEvent.ts
@@ -1,21 +1,22 @@
 import { Event } from '../../constants';
 
 import type { PlaybackState } from '../PlaybackState';
-import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
-import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
-import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
 import type { PlaybackActiveTrackChangedEvent } from './PlaybackActiveTrackChangedEvent';
+import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
 import type { PlaybackMetadataReceivedEvent } from './PlaybackMetadataReceivedEvent';
 import type { PlaybackPlayWhenReadyChangedEvent } from './PlaybackPlayWhenReadyChangedEvent';
 import type { PlaybackProgressUpdatedEvent } from './PlaybackProgressUpdatedEvent';
+import type { PlaybackQueueEndedEvent } from './PlaybackQueueEndedEvent';
+import type { PlaybackTrackChangedEvent } from './PlaybackTrackChangedEvent';
+import { PlayerErrorEvent } from './PlayerErrorEvent';
+import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
+import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
 import type { RemotePlayIdEvent } from './RemotePlayIdEvent';
 import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
-import type { RemoteSkipEvent } from './RemoteSkipEvent';
-import type { RemoteJumpForwardEvent } from './RemoteJumpForwardEvent';
-import type { RemoteJumpBackwardEvent } from './RemoteJumpBackwardEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
-import type { RemoteDuckEvent } from './RemoteDuckEvent';
+import type { RemoteSkipEvent } from './RemoteSkipEvent';
 
 export interface EventsPayloadByEvent {
   [Event.PlaybackState]: PlaybackState & { type: Event.PlaybackState };
@@ -38,6 +39,7 @@ export interface EventsPayloadByEvent {
   [Event.PlaybackProgressUpdated]: PlaybackProgressUpdatedEvent & {
     type: Event.PlaybackProgressUpdated;
   };
+  [Event.PlayerError]: PlayerErrorEvent & { type: Event.PlayerError };
   [Event.RemotePlay]: { type: Event.RemotePlay };
   [Event.RemotePlayId]: RemotePlayIdEvent & { type: Event.RemotePlayId };
   [Event.RemotePlaySearch]: RemotePlaySearchEvent & {

--- a/src/interfaces/events/PlayerErrorEvent.ts
+++ b/src/interfaces/events/PlayerErrorEvent.ts
@@ -1,0 +1,7 @@
+
+export interface PlayerErrorEvent {
+  /** The error code */
+  code: 'android-foreground-service-start-not-allowed';
+  /** The error message */
+  message: string;
+}


### PR DESCRIPTION
This pr adds to where https://github.com/doublesymmetry/react-native-track-player/pull/2028 left off

Inspired by https://github.com/Automattic/pocket-casts-android/blob/ee8da0c095560ef64a82d3a31464491b8d713104/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt#L218

- service is backgrounded on `AudioPlayerState.IDLE` and `AudioPlayerState.STOPPED`
- service is foregrounded on `AudioPlayerState.BUFFERING`, `AudioPlayerState.PLAYING`

it differs slightly from the pocket-casts implementation seeing as we don't stop foreground on pause events.