### PR TITLE
chore(example): fix android example production build

### DIFF
--- a/example/android/app/src/release/java/com/example/ReactNativeFlipper.java
+++ b/example/android/app/src/release/java/com/example/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.rndiffapp;
+package com.example;
 
 import android.content.Context;
 import com.facebook.react.ReactInstanceManager;


### PR DESCRIPTION
Fixes the following error when building the example app for production:

```
> Task :app:compileReleaseJavaWithJavac FAILED
/Users/puckey/Downloads/react-native-track-player-main/example/android/app/src/main/java/com/example/MainApplication.java:63: error: cannot find symbol
        ReactNativeFlipper.initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
        ^
  symbol:   variable ReactNativeFlipper
  location: class MainApplication
1 error

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':app:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
java.lang.StackOverflowError (no error message)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

* Get more help at https://help.gradle.org

BUILD FAILED in 31s
76 actionable tasks: 76 executed
●  ./gradlew bundleRelease

BUILD SUCCESSFUL in 7s
84 actionable tasks: 10 executed, 74 up-to-date
```