### PR TITLE
feat: useIsPlaying hook and isPlaying() method

### DIFF
--- a/docs/docs/guides/play-button.md
+++ b/docs/docs/guides/play-button.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 4
+---
+
+# Play Buttons
+
+UI often needs to display a Play button that changes between three states:
+
+1. Play
+2. Pause
+3. Spinner (e.g. if playback is being attempted, but sound is paused due to buffering)
+
+Implementing this correctly will take a bit of care. For instance, `usePlaybackState` can return `State.Buffering` even if playback is currently paused. `usePlayWhenReady` is one way to check if the player is attempting to play, but can return true even if `PlaybackState` is `State.Error` or `State.Ended`.
+
+To determine how to render a Play button in its three states correctly, do the following:
+
+* Render the button as a spinner if `playWhenReady` and `state === State.Loading || state === State.Buffering`
+* Else render the button as being in the Playing state if `playWhenReady && !(state === State.Error || state === State.Buffering)`
+* Otherwise render the button as being in the Paused state
+
+To help with this logic, the API has two utilities:
+
+1. The `useIsPlaying()` hook. This returns `{playing: boolean | undefined, bufferingDuringPlay: boolean | undefined}`, which you can consult to render your play button correctly. You should render a spinner if `bufferingDuringPlay === true`; otherwise render according to `playing`. Values are `undefined` if the player isn't yet in a state where they can be determined.
+2. The `async isPlaying()` function, which returns whether the TrackPlayer is (attempting to) play at any point. Note that you can't easily just instead call `getPlaybackState()` to determine the same answer, unless you've accounted for the issues mentioned above.

--- a/docs/docs/guides/play-button.md
+++ b/docs/docs/guides/play-button.md
@@ -21,4 +21,4 @@ To determine how to render a Play button in its three states correctly, do the f
 To help with this logic, the API has two utilities:
 
 1. The `useIsPlaying()` hook. This returns `{playing: boolean | undefined, bufferingDuringPlay: boolean | undefined}`, which you can consult to render your play button correctly. You should render a spinner if `bufferingDuringPlay === true`; otherwise render according to `playing`. Values are `undefined` if the player isn't yet in a state where they can be determined.
-2. The `async isPlaying()` function, which returns whether the TrackPlayer is (attempting to) play at any point. Note that you can't easily just instead call `getPlaybackState()` to determine the same answer, unless you've accounted for the issues mentioned above.
+2. The `async isPlaying()` function, which returns the same result as `useIsPlaying()`, but can be used outside of React components (i.e. without hooks). Note that you can't easily just instead call `getPlaybackState()` to determine the same answer, unless you've accounted for the issues mentioned above.

--- a/example/src/components/PlayPauseButton.tsx
+++ b/example/src/components/PlayPauseButton.tsx
@@ -1,33 +1,19 @@
 import React from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
-import TrackPlayer, {
-  State,
-  usePlayWhenReady,
-} from 'react-native-track-player';
-import { useDebouncedValue } from '../hooks';
+import TrackPlayer, { useIsPlaying } from 'react-native-track-player';
 import { Button } from './Button';
 
-export const PlayPauseButton: React.FC<{
-  state: State | undefined;
-}> = ({ state }) => {
-  const playWhenReady = usePlayWhenReady();
-  const isLoading = useDebouncedValue(
-    state === State.Loading || state === State.Buffering,
-    250
-  );
+export const PlayPauseButton: React.FC = () => {
+  const { playing, bufferingDuringPlay } = useIsPlaying();
 
-  const isErrored = state === State.Error;
-  const isEnded = state === State.Ended;
-  const showPause = playWhenReady && !(isErrored || isEnded);
-  const showBuffering = playWhenReady && isLoading;
-  return showBuffering ? (
+  return bufferingDuringPlay ? (
     <View style={styles.statusContainer}>
       <ActivityIndicator />
     </View>
   ) : (
     <Button
-      title={showPause ? 'Pause' : 'Play'}
-      onPress={showPause ? TrackPlayer.pause : TrackPlayer.play}
+      title={playing ? 'Pause' : 'Play'}
+      onPress={playing ? TrackPlayer.pause : TrackPlayer.play}
       type="primary"
       style={styles.playPause}
     />

--- a/example/src/components/PlayerControls.tsx
+++ b/example/src/components/PlayerControls.tsx
@@ -15,7 +15,7 @@ export const PlayerControls: React.FC = () => {
     <View style={styles.container}>
       <View style={styles.row}>
         <Button title="Prev" onPress={performSkipToPrevious} type="secondary" />
-        <PlayPauseButton state={playback.state} />
+        <PlayPauseButton />
         <Button title="Next" onPress={performSkipToNext} type="secondary" />
       </View>
       <PlaybackError

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,3 @@ export * from './usePlayWhenReady';
 export * from './usePlaybackState';
 export * from './useProgress';
 export * from './useTrackPlayerEvents';
-

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,7 @@
 export * from './useActiveTrack';
+export * from './useIsPlaying';
 export * from './usePlayWhenReady';
 export * from './usePlaybackState';
 export * from './useProgress';
 export * from './useTrackPlayerEvents';
+

--- a/src/hooks/useIsPlaying.ts
+++ b/src/hooks/useIsPlaying.ts
@@ -6,8 +6,10 @@ import { usePlaybackState } from './usePlaybackState';
 /**
  * Tells whether the TrackPlayer is in a mode that most people would describe
  * as "playing." Great for UI to decide whether to show a Play or Pause button.
- * @returns playing - whether UI should likely show as Playing
- * @returns bufferingDuringPlay - whether UI should show as Buffering
+ * @returns playing - whether UI should likely show as Playing, or undefined
+ *   if this isn't yet known.
+ * @returns bufferingDuringPlay - whether UI should show as Buffering, or
+ *   undefined if this isn't yet known.
  */
 export function useIsPlaying() {
   const state = usePlaybackState().state;
@@ -26,8 +28,8 @@ function determineIsPlaying(playWhenReady?: boolean, state?: State) {
   const isEnded = state === State.Ended;
 
   return {
-    playing: !!playWhenReady && !(isErrored || isEnded),
-    bufferingDuringPlay: !!playWhenReady && isLoading,
+    playing: playWhenReady && !(isErrored || isEnded),
+    bufferingDuringPlay: playWhenReady && isLoading,
   };
 }
 
@@ -38,6 +40,9 @@ function determineIsPlaying(playWhenReady?: boolean, state?: State) {
  *
  * It also exists whenever you need to know the play state outside of a React
  * component, since hooks only work in components.
+ *
+ * @returns playing - whether the player is attempting to play, or undefined
+ *   if this isn't yet known.
  */
 export async function isPlaying() {
   const [playbackState, playWhenReady] = await Promise.all([

--- a/src/hooks/useIsPlaying.ts
+++ b/src/hooks/useIsPlaying.ts
@@ -19,8 +19,8 @@ export function useIsPlaying() {
 }
 
 function determineIsPlaying(playWhenReady?: boolean, state?: State) {
-  if (!state) {
-    return { playing: false, bufferingDuringPlay: false };
+  if (playWhenReady === undefined || state === undefined) {
+    return { playing: undefined, bufferingDuringPlay: undefined };
   }
 
   const isLoading = state === State.Loading || state === State.Buffering;
@@ -41,15 +41,15 @@ function determineIsPlaying(playWhenReady?: boolean, state?: State) {
  * It also exists whenever you need to know the play state outside of a React
  * component, since hooks only work in components.
  *
- * @returns playing - whether the player is attempting to play, or undefined
+ * @returns playing - whether UI should likely show as Playing, or undefined
  *   if this isn't yet known.
+ * @returns bufferingDuringPlay - whether UI should show as Buffering, or
+ *   undefined if this isn't yet known.
  */
 export async function isPlaying() {
   const [playbackState, playWhenReady] = await Promise.all([
     TrackPlayer.getPlaybackState(),
     TrackPlayer.getPlayWhenReady(),
   ]);
-  const { playing } = determineIsPlaying(playWhenReady, playbackState.state);
-
-  return playing;
+  return determineIsPlaying(playWhenReady, playbackState.state);
 }

--- a/src/hooks/useIsPlaying.ts
+++ b/src/hooks/useIsPlaying.ts
@@ -1,0 +1,50 @@
+import TrackPlayer from '..';
+import { State } from '../constants';
+import { usePlayWhenReady } from './usePlayWhenReady';
+import { usePlaybackState } from './usePlaybackState';
+
+/**
+ * Tells whether the TrackPlayer is in a mode that most people would describe
+ * as "playing." Great for UI to decide whether to show a Play or Pause button.
+ * @returns playing - whether UI should likely show as Playing
+ * @returns bufferingDuringPlay - whether UI should show as Buffering
+ */
+export function useIsPlaying() {
+  const state = usePlaybackState().state;
+  const playWhenReady = usePlayWhenReady();
+
+  return determineIsPlaying(playWhenReady, state);
+}
+
+function determineIsPlaying(playWhenReady?: boolean, state?: State) {
+  if (!state) {
+    return { playing: false, bufferingDuringPlay: false };
+  }
+
+  const isLoading = state === State.Loading || state === State.Buffering;
+  const isErrored = state === State.Error;
+  const isEnded = state === State.Ended;
+
+  return {
+    playing: !!playWhenReady && !(isErrored || isEnded),
+    bufferingDuringPlay: !!playWhenReady && isLoading,
+  };
+}
+
+/**
+ * This exists if you need realtime status on whether the TrackPlayer is
+ * playing, whereas the hooks all have a delay because they depend on responding
+ * to events before their state is updated.
+ *
+ * It also exists whenever you need to know the play state outside of a React
+ * component, since hooks only work in components.
+ */
+export async function isPlaying() {
+  const [playbackState, playWhenReady] = await Promise.all([
+    TrackPlayer.getPlaybackState(),
+    TrackPlayer.getPlayWhenReady(),
+  ]);
+  const { playing } = determineIsPlaying(playWhenReady, playbackState.state);
+
+  return playing;
+}


### PR DESCRIPTION
This addresses some of the trickiness and confusion that users may have in v4's API, where `State.Buffering` spans both playing and paused states (whereas in v3, you could just `const playing = state === State.Playing || state === State.Buffering`). #2036 shows the subtlety of doing this right.

This PR adds two things to the public API:
- `useIsPlaying`: a hook that will likely be used by anyone managing a Play button. It correctly tells you when the button should be shown as "playing" and when it should be shown as "buffering."
- `isPlaying()`: an async function that gives you the most current playing state. This is needed for cases where you can't use a hook (e.g. outside of React components) or for cases where a hook's delay (due to subscriptions to events) isn't enough for you to make the right fork in your code.

I've added Javadoc-style comments, but am unsure where to update The Real Documentation™. I've also updated the example app for this simpler way of doing things.