### PR TITLE
chore(example): add android:logs command

### DIFF
--- a/example/android/scripts/logs
+++ b/example/android/scripts/logs
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+PACKAGE_NAME=com.example
+
+function monitor_logs {
+    echo "Monitoring logs for PID: $1"
+    adb logcat --pid="$1" &
+    LOGCAT_PID=$!
+
+    while adb shell "pidof -s $PACKAGE_NAME >/dev/null"; do
+        sleep 1
+    done
+
+    echo "Process $1 stopped. Killing logcat process..."
+    kill $LOGCAT_PID
+}
+
+while true; do
+    PID=$(adb shell pidof -s $PACKAGE_NAME)
+
+    if [ -n "$PID" ]; then
+        monitor_logs "$PID"
+    else
+        echo "$PACKAGE_NAME is not running. Waiting for process..."
+        sleep 1
+    fi
+done

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
     "android:uninstall": "adb uninstall com.example",
     "android:release": "cd android && ./gradlew clean && ./gradlew bundleRelease && cd app/build/outputs/bundle/release && pwd && ls",
     "android:install-release": "RD=android/app/build/outputs/bundle/release && (rm $RD/app.apks || true) && bundletool build-apks --bundle=$RD/app-release.aab --output=$RD/app.apks && (adb uninstall com.example || true) && bundletool install-apks --apks=$RD/app.apks",
+    "android:logs": "android/scripts/logs",
     "ios": "react-native run-ios",
     "ios:ide": "open ios/*.xcworkspace/",
     "windows": "react-native run-windows",


### PR DESCRIPTION
Call `yarn android:logs` to see all `adb logcat` output from the example app running on android. If the process isn’t started yet, it will wait for it. If the process is restarted, logging will also restart.