### PR TITLE
refactor: don't recreate INITIAL on every re-render

### DIFF
--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -5,20 +5,21 @@ import { Event } from '../constants';
 import type { Progress } from '../interfaces';
 import { useTrackPlayerEvents } from './useTrackPlayerEvents';
 
+const INITIAL = {
+  position: 0,
+  duration: 0,
+  buffered: 0,
+};
+
 /**
  * Poll for track progress for the given interval (in miliseconds)
  * @param updateInterval - ms interval
  */
 export function useProgress(updateInterval = 1000) {
-  const INITIAL = {
-    position: 0,
-    duration: 0,
-    buffered: 0,
-  };
   const [state, setState] = useState<Progress>(INITIAL);
 
   useTrackPlayerEvents([Event.PlaybackActiveTrackChanged], () => {
-    setState(INITIAL);
+    setState({...INITIAL});
   });
 
   useEffect(() => {


### PR DESCRIPTION
Really minor optimisation which avoids object re-creation/destructurization on every re-render.

Since `useProgress` changes its state every second, every second it'll create a new object and then move it to GC. In my opinion it could be avoided and `INITIAL` variable can be initialized only one time 🙂 

Note, that current code doesn't introduce any performance issues - this PR it's really minor optimization 🙂 