### PR TITLE
chore: lifecycle-process version downgrade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,6 +59,6 @@ dependencies {
     // Make sure we're using androidx
     implementation "androidx.core:core-ktx:1.9.0"
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
-    implementation "androidx.lifecycle:lifecycle-process:2.6.1"
+    implementation "androidx.lifecycle:lifecycle-process:2.5.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3"
 }


### PR DESCRIPTION

`lifecycle-process:2.6.1` requires version 1.8.0 or later

However, since the `react-native@0.69` version uses the 1.6.0 version, we would like to downgrade it to a version that is possible.

There doesn't seem to be much of a difference between 2.6.1 and 2.5.1, and it doesn't look like `react-native-track-player` are using code from 2.5.1 onwards.

---

link: https://developer.android.com/jetpack/androidx/releases/lifecycle
https://androidx.tech/artifacts/lifecycle/lifecycle-process/2.5.1