### PR TITLE
docs: update typo for zustand

### DIFF
--- a/docs/docs/guides/multitrack-progress.md
+++ b/docs/docs/guides/multitrack-progress.md
@@ -83,7 +83,7 @@ export const useTrackProgress = (id: string | number): number => {
 #### 2. Listen To Progress Updates
 
 Next we need to set up a listener for progress updates in our
-[playback service](../basics/playback-service.md) and update our zustonad store:
+[playback service](../basics/playback-service.md) and update our zustand store:
 
 ```ts
 // src/services/PlaybackService.ts

--- a/docs/versioned_docs/version-3.1/guides/multitrack-progress.md
+++ b/docs/versioned_docs/version-3.1/guides/multitrack-progress.md
@@ -83,7 +83,7 @@ export const useTrackProgress = (id: string | number): number => {
 #### 2. Listen To Progress Updates
 
 Next we need to set up a listener for progress updates in our
-[playback service](../basics/playback-service.md) and update our zustonad store:
+[playback service](../basics/playback-service.md) and update our zustand store:
 
 ```ts
 // src/services/PlaybackService.ts

--- a/docs/versioned_docs/version-3.2/guides/multitrack-progress.md
+++ b/docs/versioned_docs/version-3.2/guides/multitrack-progress.md
@@ -83,7 +83,7 @@ export const useTrackProgress = (id: string | number): number => {
 #### 2. Listen To Progress Updates
 
 Next we need to set up a listener for progress updates in our
-[playback service](../basics/playback-service.md) and update our zustonad store:
+[playback service](../basics/playback-service.md) and update our zustand store:
 
 ```ts
 // src/services/PlaybackService.ts


### PR DESCRIPTION
Fixed `zustonad` typo with `zustand` in the Multitrack Progress guide