### PR TITLE
fix(android): updateOptions spread

### DIFF
--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -224,6 +224,7 @@ export async function updateOptions({
   ...options
 }: UpdateOptions = {}): Promise<void> {
   return TrackPlayer.updateOptions({
+    ...options,
     android: {
       // Handle deprecated alwaysPauseOnInterruption option:
       alwaysPauseOnInterruption:
@@ -238,7 +239,6 @@ export async function updateOptions({
     nextIcon: resolveImportedAsset(options.nextIcon),
     rewindIcon: resolveImportedAsset(options.rewindIcon),
     forwardIcon: resolveImportedAsset(options.forwardIcon),
-    ...options,
   });
 }
 


### PR DESCRIPTION
moves the options spread introduced in TrackPlayer.updateOptions from #2033 up, so the old options data doesnt spread and block android options and resolved icon paths.