### PR TITLE
docs(3.2): Fixed typo in media file URL

### DIFF
--- a/docs/versioned_docs/version-3.2/basics/getting-started.md
+++ b/docs/versioned_docs/version-3.2/basics/getting-started.md
@@ -61,7 +61,7 @@ const track2 = {
 };
 
 const track3 = {
-    url: 'file:///storage/sdcard0/Downloads/artwork.png', // Load media from the file system
+    url: 'file:///storage/sdcard0/Downloads/iceage.mp3', // Load media from the file system
     title: 'Ice Age',
     artist: 'deadmau5',
      // Load artwork from the file system:


### PR DESCRIPTION
Fixed a typo in the repository where the media file URL was incorrectly pointing to 'artwork.png' instead of 'iceage.mp3.' This correction ensures that users are not confused, as 'artwork.png' might lead them to believe they should point to an artwork file rather than the intended media file.