### PR TITLE
fix: useIsPlaying hook does not cover 'none' state

### DIFF
--- a/src/hooks/useIsPlaying.ts
+++ b/src/hooks/useIsPlaying.ts
@@ -26,9 +26,10 @@ function determineIsPlaying(playWhenReady?: boolean, state?: State) {
   const isLoading = state === State.Loading || state === State.Buffering;
   const isErrored = state === State.Error;
   const isEnded = state === State.Ended;
+  const isNone = state === State.None;
 
   return {
-    playing: playWhenReady && !(isErrored || isEnded),
+    playing: playWhenReady && !(isErrored || isEnded || isNone),
     bufferingDuringPlay: playWhenReady && isLoading,
   };
 }


### PR DESCRIPTION
In case if there is only one track in queue, after removing the track the hook is still returing playing as true. There is no condition which is checking 'none' state.