### PR TITLE
fix: don't emit `PlaybackTrackChanged` along with `PlaybackQueueEnded` on Android

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -594,7 +594,6 @@ class MusicService : HeadlessJsTaskService() {
 
                 if (it == AudioPlayerState.ENDED && player.nextItem == null) {
                     emitQueueEndedEvent()
-                    emitPlaybackTrackChangedEvents(null, player.currentIndex, player.position.toSeconds())
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/doublesymmetry/react-native-track-player/issues/2160

It seems like original changes were introduced in https://github.com/doublesymmetry/react-native-track-player/commit/5ba6c77ac125aef990b56b5a8a08f75a8e6f9a65

@dcvz do you remember why you've added this code? It doesn't contain any references to any issues, so wanted to check with you why it was needed 👀 