### PR TITLE
fix(ios): rate in command center progress

### DIFF
--- a/react-native-track-player.podspec
+++ b/react-native-track-player.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.swift_version = "4.2"
 
   s.dependency "React-Core"
-  s.dependency "SwiftAudioEx", "1.0.0-rc.9"
+  s.dependency "SwiftAudioEx", "1.0.0-rc.10"
 end


### PR DESCRIPTION
Fixes an issue where changing the rate for playback would not update the notification until you paused or changed player state. Making the progress bar there run at a different rate.