### PR TITLE
fix: android notification removal flag when mediasession focus changed

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -590,7 +590,7 @@ class MusicService : HeadlessJsTaskService() {
                                 delay(stopForegroundGracePeriod.toLong() * 1000)
                                 if (shouldStopForeground()) {
                                     @Suppress("DEPRECATION")
-                                    stopForeground(true)
+                                    stopForeground(removeNotificationWhenNotOngoing)
                                     Timber.d("Notification has been stopped")
                                 }
                             }


### PR DESCRIPTION
I started noticing in my app using nightly, the notification when media is not played will get removed when app enters background. This is caused by stopForeground is set to always remove notification when ForegroundGracePeriod expires.
this fix reverts the removeNotificationWhenNotOngoing flag in stopForeground introduced in b13a92208eaf9607a12cfa7596dfa6ae4f4a4c8e and fixes my issue.