### PR TITLE
refactor: the docs now recommend using the remove function on the AppState subscription

### DIFF
--- a/src/hooks/useAppIsInBackground.ts
+++ b/src/hooks/useAppIsInBackground.ts
@@ -9,10 +9,10 @@ export function useAppIsInBackground() {
       setState(nextState);
     };
 
-    AppState.addEventListener('change', onStateChange);
+    const subscription = AppState.addEventListener('change', onStateChange);
 
     return () => {
-      AppState.removeEventListener('change', onStateChange);
+      subscription.remove()
     };
   }, []);
   return state === 'background';


### PR DESCRIPTION
This pull request addresses the deprecation of AppState.removeEventListener in favor of the recommended alternative in the React Native documentation. The changes ensure that the useAppIsInBackground hook remains up-to-date with the latest best practices.

React Native has deprecated AppState.removeEventListener in favor of a more robust and future-proof alternative. This change ensures that our codebase aligns with the latest recommendations, reducing the risk of issues in the future.