### PR TITLE
Fix not_initialized error code

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -140,7 +140,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
     private func rejectWhenNotInitialized(reject: RCTPromiseRejectBlock) -> Bool {
         let rejected = !hasInitialized;
         if (rejected) {
-            reject("player_already_initialized", "The player is not initialized. Call setupPlayer first.", nil)
+            reject("player_not_initialized", "The player is not initialized. Call setupPlayer first.", nil)
         }
         return rejected;
     }


### PR DESCRIPTION
The error-code that is emitted when the player is not initialized is the same as when the player is already initialized (the error messages themselves are okay).