### PR TITLE
chore(android): distinguish url and artwork empty string error message

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/utils/BundleUtils.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/utils/BundleUtils.kt
@@ -16,7 +16,7 @@ object BundleUtils {
         val obj = data[key]
         if (obj is String) {
             // Remote or Local Uri
-            if (obj.trim { it <= ' ' }.isEmpty()) throw RuntimeException("The URL cannot be empty")
+            if (obj.trim { it <= ' ' }.isEmpty()) throw RuntimeException("$key: The URL cannot be empty")
             return Uri.parse(obj as String?)
         } else if (obj is Bundle) {
             // require/import


### PR DESCRIPTION
Current error message is not descriptive enough and empty artwork url string may be considered as an empty track url field. The player throws an error, so it would be good to catch the artwork may be the problem