### PR TITLE
feat: now playing metadata changed hook and event

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -51,6 +51,7 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val METADATA_TIMED_RECEIVED = "metadata-timed-received"
         const val METADATA_COMMON_RECEIVED = "metadata-common-received"
         const val METADATA_PAYLOAD_KEY = "metadata"
+        const val NOW_PLAYING_METADATA_CHANGED = "now-playing-metadata-changed"
 
         // Other
         const val PLAYER_ERROR = "player-error"

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -364,6 +364,13 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     }
 
     @ReactMethod
+    fun getNowPlayingMetadata(callback: Promise) = scope.launch {
+        if (verifyServiceBoundOrReject(callback)) return@launch
+
+        callback.resolve(Arguments.fromBundle(musicService.getNowPlayingMetadata()))
+    }
+
+    @ReactMethod
     fun clearNowPlayingMetadata(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
 
@@ -371,6 +378,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
             callback.reject("no_current_item", "There is no current item in the player")
 
         musicService.clearNotificationMetadata()
+        musicService.updateNowPlayingMetadata(bundleToTrack(Bundle()))
         callback.resolve(null)
     }
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -46,6 +46,7 @@ class MusicService : HeadlessJsTaskService() {
     private val binder = MusicBinder()
     private val scope = MainScope()
     private var progressUpdateJob: Job? = null
+    private var nowPlayingMetadata: Bundle? = Bundle()
 
     /**
      * Use [appKilledPlaybackBehavior] instead.
@@ -434,6 +435,18 @@ class MusicService : HeadlessJsTaskService() {
     @MainThread
     fun updateNowPlayingMetadata(track: Track) {
         player.notificationManager.overrideMetadata(track.toAudioItem())
+
+        nowPlayingMetadata = track.originalItem
+
+        val eventPayload = Bundle()
+        eventPayload.putBundle("metadata", nowPlayingMetadata!!.clone() as Bundle)
+
+        emit(MusicEvents.NOW_PLAYING_METADATA_CHANGED, eventPayload);
+    }
+
+    @MainThread
+    fun getNowPlayingMetadata(): Bundle {
+        return nowPlayingMetadata ?: Bundle()
     }
 
     @MainThread

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -430,6 +430,15 @@ class MusicService : HeadlessJsTaskService() {
     @MainThread
     fun updateMetadataForTrack(index: Int, track: Track) {
         player.replaceItem(index, track.toAudioItem())
+
+        if (player.currentIndex == index) {
+          nowPlayingMetadata = track.originalItem
+
+          val eventPayload = Bundle()
+          eventPayload.putBundle("metadata", nowPlayingMetadata!!.clone() as Bundle)
+
+          emit(MusicEvents.NOW_PLAYING_METADATA_CHANGED, eventPayload);
+        }
     }
 
     @MainThread

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -26,6 +26,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
     private var sessionCategoryMode: AVAudioSession.Mode = .default
     private var sessionCategoryPolicy: AVAudioSession.RouteSharingPolicy = .default
     private var sessionCategoryOptions: AVAudioSession.CategoryOptions = []
+    private var nowPlayingMetadata: [String: Any] = [:]
 
     // MARK: - Lifecycle Methods
 
@@ -695,6 +696,13 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         }
     }
 
+    @objc(getNowPlayingMetadata:rejecter:)
+    public func getNowPlayingMetadata(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        if (rejectWhenNotInitialized(reject: reject)) { return }
+
+        resolve(nowPlayingMetadata)
+    }
+
     @objc(getDuration:rejecter:)
     public func getDuration(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if (rejectWhenNotInitialized(reject: reject)) { return }
@@ -754,6 +762,11 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
 
         player.nowPlayingInfoController.clear()
         resolve(NSNull())
+
+        nowPlayingMetadata = [:]
+        emit(event: EventType.NowPlayingMetadataChanged, body: [
+                "metadata": [:],
+            ] as [String : Any])
     }
 
     @objc(updateNowPlayingMetadata:resolver:rejecter:)
@@ -761,6 +774,11 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         if (rejectWhenNotInitialized(reject: reject)) { return }
 
         Metadata.update(for: player, with: metadata)
+        nowPlayingMetadata = metadata
+        emit(event: EventType.NowPlayingMetadataChanged, body: [
+                "metadata": metadata,
+            ] as [String : Any])
+
         resolve(NSNull())
     }
 

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -751,6 +751,10 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
 
         if (player.currentIndex == index) {
             Metadata.update(for: player, with: metadata)
+            nowPlayingMetadata = metadata
+            emit(event: EventType.NowPlayingMetadataChanged, body: [
+                    "metadata": metadata,
+                ] as [String : Any])
         }
 
         resolve(NSNull())

--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.m
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.m
@@ -164,4 +164,7 @@ RCT_EXTERN_METHOD(sleepWhenActiveTrackReachesEnd:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(clearSleepTimer:(RCTPromiseResolveBlock)resolve
               rejecter:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(getNowPlayingMetadata:(RCTPromiseResolveBlock)resolve
+              rejecter:(RCTPromiseRejectBlock)reject);
+
 @end

--- a/ios/RNTrackPlayer/Utils/EventType.swift
+++ b/ios/RNTrackPlayer/Utils/EventType.swift
@@ -26,6 +26,7 @@ enum EventType: String, CaseIterable {
     case MetadataChapterReceived = "metadata-chapter-received"
     case MetadataTimedReceived = "metadata-timed-received"
     case MetadataCommonReceived = "metadata-common-received"
+    case NowPlayingMetadataChanged = "now-playing-metadata-changed"
     
     static func allRawValues() -> [String] {
         return allCases.map { $0.rawValue }

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -131,4 +131,8 @@ export enum Event {
    * See https://rntp.dev/docs/api/events#commonmetadatareceived
    **/
   MetadataCommonReceived = 'metadata-common-received',
+  /**
+   * Fired when metadata of active track has changed.
+   **/
+  NowPlayingMetadataChanged = 'now-playing-metadata-changed',
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,5 @@ export * from './usePlayWhenReady';
 export * from './usePlaybackState';
 export * from './useProgress';
 export * from './useTrackPlayerEvents';
+export * from './useNowPlayingMetadata';
+

--- a/src/hooks/useNowPlayingMetadata.ts
+++ b/src/hooks/useNowPlayingMetadata.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Event } from '../constants';
+import { useTrackPlayerEvents } from './useTrackPlayerEvents';
+import { NowPlayingMetadata } from '../interfaces';
+import TrackPlayer from '..';
+
+export const useNowPlayingMetadata = (): NowPlayingMetadata | undefined => {
+  const [metadata, setMetadata] = useState<NowPlayingMetadata | undefined>();
+
+  useEffect(() => {
+    let unmounted = false;
+
+    if (unmounted) return;
+
+    TrackPlayer.getNowPlayingMetadata()
+    .then(setMetadata)
+      .catch(() => {
+        /** Only throws while you haven't yet setup, ignore failure. */
+      });
+
+      return () => {
+        unmounted = true;
+      };
+  }, [])
+
+  useTrackPlayerEvents(
+    [Event.NowPlayingMetadataChanged],
+    async (event) => {
+      setMetadata(event.metadata);
+    }
+  );
+
+  return metadata;
+};

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -19,6 +19,7 @@ import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
 import type { RemoteSkipEvent } from './RemoteSkipEvent';
+import type { NowPlayingMetadataChangedEvent } from './NowPlayingMetadataChangedEvent';
 
 export type EventPayloadByEvent = {
   [Event.PlayerError]: PlayerErrorEvent;
@@ -49,6 +50,7 @@ export type EventPayloadByEvent = {
   [Event.MetadataChapterReceived]: AudioMetadataReceivedEvent;
   [Event.MetadataTimedReceived]: AudioMetadataReceivedEvent;
   [Event.MetadataCommonReceived]: AudioCommonMetadataReceivedEvent;
+  [Event.NowPlayingMetadataChanged]: NowPlayingMetadataChangedEvent;
 };
 
 // eslint-disable-next-line

--- a/src/interfaces/events/NowPlayingMetadataChangedEvent.ts
+++ b/src/interfaces/events/NowPlayingMetadataChangedEvent.ts
@@ -1,0 +1,5 @@
+import type { NowPlayingMetadata } from "../NowPlayingMetadata";
+
+export interface NowPlayingMetadataChangedEvent {
+  metadata: NowPlayingMetadata;
+}

--- a/src/interfaces/events/index.ts
+++ b/src/interfaces/events/index.ts
@@ -14,3 +14,4 @@ export * from './RemotePlaySearchEvent';
 export * from './RemoteSeekEvent';
 export * from './RemoteSetRatingEvent';
 export * from './RemoteSkipEvent';
+export * from './NowPlayingMetadataChangedEvent';

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -281,6 +281,13 @@ export function updateNowPlayingMetadata(
   });
 }
 
+/**
+ * Gets the metadata content of the notification (Android) and the Now Playing Center (iOS).
+ */
+export async function getNowPlayingMetadata(): Promise<NowPlayingMetadata | undefined> {
+  return (await TrackPlayer.getNowPlayingMetadata()) ?? undefined;
+}
+
 // MARK: - Player API
 
 /**


### PR DESCRIPTION
## Summary

Resolves https://github.com/doublesymmetry/react-native-track-player/issues/2158.


Added `nowPlayingMetadata` hook, `getNowPlayingMetadata` getter and `NowPlayingMetadataChanged` event.
Reflect these changes in `updateMetadataForTrack` (when it's the active track) and `clearNowPlayingMetadata` for time before deprecation.

`useActiveTrack()` stays intact, as David suggested in issue, I've done changes as per his recommendations, implementing new event, getter and hook, independently of `useActiveTrack`.

- Users had no way of obtaining now playing metadata before, for metadata rendering purposes
  - `activeTrack` event, getter and hook do not provide now playing metadata information - if users would ever change
metadata of track that is currently playing, there would be no update to it
  - With radio streams, when rendering now playing metadata artist, title and artwork... Radio screen metadata UI can be updated once `MetadataTimedReceived` event is emitted. But, if user would unmount the screen and then come back to it, now playing metadata is not accessible, until new `MetadataTimedReceived` event is emitted - when song on the radio stream changes
  
### How it works
- Every time `updateNowPlayingMetadata`, or `updateMetadataForTrack`, if it's active track, is called, new metadata is saved into private var inside `MusicService` / `RNTrackPlayer` and `NowPlayingMetadataChanged` event is emitted. `clearNowPlayingMetadata` reflects these changes accordingly, until it'll be deprecated as announced
- `getNowPlayingMetadata` returns that variable's value, last stored metadata
- `useNowPlayingMetadata` fetches that variable's value on mount, saves it into state. Every time `NowPlayingMetadataChanged` is emitted, it updates the internal state with new metadata. Hook returns metadata
- `NowPlayingMetadataChanged` is subscribable, event returns `metadata` object

### Testing
- Tested in Example app, using iPhone 13 mini (iOS 17.2) and Google Pixel 3 (Android 12)
- Tested in my app containing podcast RSS feeds and radio streams, using iPhone 13 mini (iOS 17.2) and Google Pixel 3 (Android 12)


### Screenshots

Note that artwork gets updated randomly, and because notification metadata and our `nowPlayingMetadata` update at at different time, they're not the same.
<table>
<tr>
<td colSpan="2">Now playing metadata updated on "Update Notification Metadata Randomly" action</td>
<td colSpan="2">Now playing metadata updated on "Update Current Track Metadata Randomly" action</td>
</tr>
<tr>
<td colSpan="4">iOS</td>
</tr>
<tr>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/1628ef5c-305f-40a2-b24a-a905b97e3281" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/0bdb8823-34b6-4d84-a54a-28dd6d507ebc" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/831d34de-8118-4833-9b5d-8685be87c5f0" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/36d30ee4-f518-4638-9884-b169d3205116" /></td>
</tr>

<tr>
<td colSpan="4">Android</td>
</tr>
<tr>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/009fe294-36e8-4a52-a72b-c85a2a9de03f" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/0dddcfee-ff2f-4cfd-a791-4f252db2bf70" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/80def4df-aeb7-4e81-8ab4-d2073ae28084" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/6f4ed749-9d86-41bf-85c9-f9e133571a7e" /></td>
</tr>
</table>


<table>
<tr>
<td colSpan="9">Now playing metadata updated for each track via PlaybackService</td>
</tr>
<tr>
<td colSpan="9">iOS</td>
</tr>
<tr>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/f3634848-51b6-4116-94a0-47384b1441db" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/e9277ed9-b9df-4972-9699-7fa393b9f8f7" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/f6e4aabf-5af2-4a67-991b-4830e2ee9ecb" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/a869f99b-c6cc-486a-83d4-75e60fc734c6" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/3a352813-95bd-4b78-99d4-4f6ff52124f1" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/1c0383df-3489-4cff-8b8d-cf803aa9635b" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/75fafc7e-714a-4bdd-9e8f-a24393bec835" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/2904de9e-ca8f-4322-aa4b-856756fa8e3b" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/c4c1f622-b12d-4e6b-aa5d-83bfdc88422b" /></td>
</tr>
<tr>
<td colSpan="9">Android</td>
</tr>
<tr>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/e825953d-57fa-4618-badc-923e101bbaff" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/b88fe95c-8ec5-4740-a7dd-f206ba71039c" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/bbb0df68-527c-453b-a065-6aff8880a0b6" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/567358c5-d323-4122-9b35-6602c1d420f7" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/a8526df4-cef6-470e-b675-de521980c339" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/e25585f4-301c-4595-8d88-da4d5ffdbd74" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/54527d6f-2d5d-44a1-a51e-2810182da811" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/4a9d40e5-afa8-4f6c-a756-6451bd5402ad" /></td>
<td><img src="https://github.com/doublesymmetry/react-native-track-player/assets/57353746/4f4d6723-2a6d-4dff-9f61-64beee79917b" /></td>
</tr>
</table>

## Note
@dcvz 
I've just noticed that notification metadata is "patched", instead of replaced.
E.g., if we update now playing metadata, or metadata for active track, it'll keep old metadata values for any undefined values in object we're updating with.
I'm not sure if this should be the case, I'd expect users to be able to override notification data completely.
`nowPlayingMetadata` is replaced completely with new values, even if they're undefined.