### PR TITLE
chore: reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "src",
     "lib/**/*",
     "ios/**/*",
-    "android/**/*",
+    "android/src/**/*",
+    "android/build.gradle",
+    "android/proguard-rules.txt",
     "*.podspec"
   ],
   "contributors": [


### PR DESCRIPTION
Current npm package size is ~13mb:

<img width="1187" alt="image" src="https://github.com/doublesymmetry/react-native-track-player/assets/22820318/b442707a-c08b-4d06-990c-5aa304ebc3ca">

Which is quite a lot for npm package. And it's mainly because of the fact that build files are included.

We ignore these files in `.npmignore`, but we use `files` property in `package.json` (which kind of has higher priority, so `.npmignore` properties are ignored).

In this PR I included files that are really needed (and omitted unnecessary files/directories, such as build/.idea/etc)

|Before|After|
|-------|-----|
|<img width="604" alt="image" src="https://github.com/doublesymmetry/react-native-track-player/assets/22820318/f80f277b-4d84-4374-a254-35ff3d256723">|<img width="605" alt="image" src="https://github.com/doublesymmetry/react-native-track-player/assets/22820318/dfbfb803-f7e9-450e-94f5-3bd5e734b35c">|