### PR TITLE
feat: adds iosCategory update functionality

### DIFF
--- a/docs/docs/api/objects/update-options.md
+++ b/docs/docs/api/objects/update-options.md
@@ -25,5 +25,8 @@ All parameters are optional. You also only need to specify the ones you want to 
 | `forwardIcon` | [Resource Object](../objects/resource.md) | The jump forward icon¹ | ✅ | ❌ | ❌ |
 | `color` | `number` | The notification color in an ARGB hex | ✅ | ❌ | ❌ |
 | `progressUpdateEventInterval` | `number` | The interval (in seconds) that the [`Event.PlaybackProgressUpdated`](../events.md#playbackprogressupdated) will be fired. `undefined` by default. | ✅ | ✅ | ❌ |
+| options.iosCategory  | `IOSCategory` | [AVAudioSession.Category](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616615-category) for iOS. Sets on `play()` | `IOSCategory.Playback` | ❌ | ✅ | ❌ |
+| options.iosCategoryOptions | `IOSCategoryOptions[]` | [AVAudioSession.CategoryOptions](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616503-categoryoptions) for iOS. Sets on `play()` | `[]` | ❌ | ✅ | ❌ |
+| options.iosCategoryMode  | `IOSCategoryMode` | [AVAudioSession.Mode](https://developer.apple.com/documentation/avfoundation/avaudiosession/1616508-mode) for iOS. Sets on `play()` | `default` | ❌ | ✅ | ❌ |
 
 *¹ - The custom icons will only work in release builds*

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -140,7 +140,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
     private func rejectWhenNotInitialized(reject: RCTPromiseRejectBlock) -> Bool {
         let rejected = !hasInitialized;
         if (rejected) {
-            reject("player_already_initialized", "The player is not initialized. Call setupPlayer first.", nil)
+            reject("player_not_initialized", "The player is not initialized. Call setupPlayer first.", nil)
         }
         return rejected;
     }

--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -140,7 +140,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
     private func rejectWhenNotInitialized(reject: RCTPromiseRejectBlock) -> Bool {
         let rejected = !hasInitialized;
         if (rejected) {
-            reject("player_not_initialized", "The player is not initialized. Call setupPlayer first.", nil)
+            reject("player_already_initialized", "The player is not initialized. Call setupPlayer first.", nil)
         }
         return rejected;
     }
@@ -183,28 +183,7 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         // configure wether control center metdata should auto update
         player.automaticallyUpdateNowPlayingInfo = config["autoUpdateMetadata"] as? Bool ?? true
 
-        // configure audio session - category, options & mode
-        if
-            let sessionCategoryStr = config["iosCategory"] as? String,
-            let mappedCategory = SessionCategory(rawValue: sessionCategoryStr) {
-            sessionCategory = mappedCategory.mapConfigToAVAudioSessionCategory()
-        }
-
-        if
-            let sessionCategoryModeStr = config["iosCategoryMode"] as? String,
-            let mappedCategoryMode = SessionCategoryMode(rawValue: sessionCategoryModeStr) {
-            sessionCategoryMode = mappedCategoryMode.mapConfigToAVAudioSessionCategoryMode()
-        }
-
-        if
-            let sessionCategoryPolicyStr = config["iosCategoryPolicy"] as? String,
-            let mappedCategoryPolicy = SessionCategoryPolicy(rawValue: sessionCategoryPolicyStr) {
-            sessionCategoryPolicy = mappedCategoryPolicy.mapConfigToAVAudioSessionCategoryPolicy()
-        }
-
-        let sessionCategoryOptsStr = config["iosCategoryOptions"] as? [String]
-        let mappedCategoryOpts = sessionCategoryOptsStr?.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() } ?? []
-        sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
+        updateCategory(config: config)
 
         configureAudioSession()
 
@@ -291,6 +270,30 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         resolve(NSNull())
     }
 
+    private func updateCategory(config: [String: Any]) {
+        // configure audio session - category, options & mode
+        if
+            let sessionCategoryStr = config["iosCategory"] as? String,
+            let mappedCategory = SessionCategory(rawValue: sessionCategoryStr) {
+            sessionCategory = mappedCategory.mapConfigToAVAudioSessionCategory()
+        }
+
+        if
+            let sessionCategoryModeStr = config["iosCategoryMode"] as? String,
+            let mappedCategoryMode = SessionCategoryMode(rawValue: sessionCategoryModeStr) {
+            sessionCategoryMode = mappedCategoryMode.mapConfigToAVAudioSessionCategoryMode()
+        }
+
+        if
+            let sessionCategoryPolicyStr = config["iosCategoryPolicy"] as? String,
+            let mappedCategoryPolicy = SessionCategoryPolicy(rawValue: sessionCategoryPolicyStr) {
+            sessionCategoryPolicy = mappedCategoryPolicy.mapConfigToAVAudioSessionCategoryPolicy()
+        }
+
+        let sessionCategoryOptsStr = config["iosCategoryOptions"] as? [String]
+        let mappedCategoryOpts = sessionCategoryOptsStr?.compactMap { SessionCategoryOptions(rawValue: $0)?.mapConfigToAVAudioSessionCategoryOptions() } ?? []
+        sessionCategoryOptions = AVAudioSession.CategoryOptions(mappedCategoryOpts)
+    }
 
     private func configureAudioSession() {
 
@@ -345,6 +348,10 @@ public class RNTrackPlayer: RCTEventEmitter, AudioSessionControllerDelegate {
         configureProgressUpdateEvent(
             interval: ((options["progressUpdateEventInterval"] as? NSNumber) ?? 0).doubleValue
         )
+
+        updateCategory(config: options)
+
+        configureAudioSession()
 
         resolve(NSNull())
     }


### PR DESCRIPTION
**Why**

It allows you to switch modes at run time. For example, if you have an app that plays both audio and video you may need to update the `iosCategoryMode` at runtime 

For some reason we found that to get CarPlay to broadcast the audio from track player using audio it needs IOSCategoryMode.SpokenAudio and for video it needs IOSCategoryMode.VideoRecording.

**How**

I moved some of the logic into an `updateCategory` function so it can be reused and the `iosCategoryMode` can be updated as well as other ios properties (see docs I've updated)