### PR TITLE
fix(android): app crash in the background when the notification of th…

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -120,9 +120,16 @@ class MusicService : HeadlessJsTaskService() {
             notificationBuilder.foregroundServiceBehavior = NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE
         }
         val notification = notificationBuilder.build()
-        startForeground(EMPTY_NOTIFICATION_ID, notification)
-        @Suppress("DEPRECATION")
-        stopForeground(true)
+        try {
+            startForeground(EMPTY_NOTIFICATION_ID, notification)
+            @Suppress("DEPRECATION")
+            stopForeground(true)
+        } catch (error: Exception) {
+            Timber.e(
+                "ForegroundServiceStartNotAllowedException: App tried to start a foreground Service when it was not allowed to do so.",
+                error
+            )
+        }
     }
 
     @MainThread


### PR DESCRIPTION
**Describe the Bug**
There are lots of reports about the crash log
```
android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service nl.sajansen.hymnbook2/com.doublesymmetry.trackplayer.service.MusicService
  android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel (ForegroundServiceStartNotAllowedException.java:54)
  android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel (ForegroundServiceStartNotAllowedException.java:50)
  android.os.Parcel.readParcelableInternal (Parcel.java:4882)
  android.os.Parcel.readParcelable (Parcel.java:4864)
  android.os.Parcel.createExceptionOrNull (Parcel.java:3064)
  android.os.Parcel.createException (Parcel.java:3053)
  android.os.Parcel.readException (Parcel.java:3036)
  android.os.Parcel.readException (Parcel.java:2978)
  android.app.IActivityManager$Stub$Proxy.setServiceForeground (IActivityManager.java:7214)
  android.app.Service.startForeground (Service.java:775)
  com.doublesymmetry.trackplayer.service.MusicService.startAndStopEmptyNotificationToAvoidANR (MusicService.kt:123)
  com.doublesymmetry.trackplayer.service.MusicService.onStartCommand (MusicService.kt:98)
  android.app.ActivityThread.handleServiceArgs (ActivityThread.java:5268)
  android.app.ActivityThread.-$$Nest$mhandleServiceArgs (Unknown source)
  android.app.ActivityThread$H.handleMessage (ActivityThread.java:2531)
  android.os.Handler.dispatchMessage (Handler.java:106)
  android.os.Looper.loopOnce (Looper.java:230)
  android.os.Looper.loop (Looper.java:319)
  android.app.ActivityThread.main (ActivityThread.java:8893)
  java.lang.reflect.Method.invoke (Method.java:-2)
  com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
java.lang.RuntimeException: Unable to start service com.doublesymmetry.trackplayer.service.MusicService@7af617a with null: android.app.ForegroundServiceStartNotAllowedException: Service.startForeground() not allowed due to mAllowStartForeground false: service nl.sajansen.hymnbook2/com.doublesymmetry.trackplayer.service.MusicService
  android.app.ActivityThread.handleServiceArgs (ActivityThread.java:5286)
  android.app.ActivityThread.-$$Nest$mhandleServiceArgs (Unknown source)
  android.app.ActivityThread$H.handleMessage (ActivityThread.java:2531)
  android.os.Handler.dispatchMessage (Handler.java:106)
  android.os.Looper.loopOnce (Looper.java:230)
  android.os.Looper.loop (Looper.java:319)
  android.app.ActivityThread.main (ActivityThread.java:8893)
  java.lang.reflect.Method.invoke (Method.java:-2)
  com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```

**Steps To Reproduce**
1. start the app with the library initialized
2. put the app to background
3. go to settings of the app and turn the notification off
4. wait for 5-10 seconds
5. the app crashes in the background

**Related Issues**
it should fix the issue https://github.com/doublesymmetry/react-native-track-player/issues/2244