### PR TITLE
fix(web): playlist queue logic

### DIFF
--- a/web/TrackPlayer/PlaylistPlayer.ts
+++ b/web/TrackPlayer/PlaylistPlayer.ts
@@ -29,6 +29,8 @@ export class PlaylistPlayer extends Player {
       case RepeatMode.Playlist:
         if (this.currentIndex === this.playlist.length - 1) {
           await this.goToIndex(0);
+        } else {
+          await this.skipToNext();
         }
         break;
       default:
@@ -38,7 +40,6 @@ export class PlaylistPlayer extends Player {
           if ((err as Error).message !== 'playlist_exhausted') {
             throw err;
           }
-
           this.onPlaylistEnded();
         }
         break;
@@ -79,7 +80,7 @@ export class PlaylistPlayer extends Player {
   }
 
   public async add(tracks: Track[], insertBeforeIndex?: number) {
-    if (insertBeforeIndex) {
+    if (insertBeforeIndex !== -1 && insertBeforeIndex !== undefined) {
       this.playlist.splice(insertBeforeIndex, 0, ...tracks);
     } else {
       this.playlist.push(...tracks);


### PR DESCRIPTION
There were at least 2 bugs that occured in my project using react-native-web:

1. Adding new songs to the end would instead insert them at index 1. This is because in an earlier function you would set an undefined parameter to -1, after evaluating if this value is set you forgot to also check for -1

2. The next song would not play if the repeat mode is set to Queue because it would never get to the logic if it should play the next song.

This PR should fix the issues. :)