### PR TITLE
fix(web): removed dynamic shaka-player import

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "module": "esnext",
     "skipLibCheck": true
   },
-  "include": ["src"],
+  "include": ["src", "web"],
   "exclude": ["node_modules", "**/__tests__/*"]
 }

--- a/web/TrackPlayer/Player.ts
+++ b/web/TrackPlayer/Player.ts
@@ -1,7 +1,6 @@
 import { State } from '../../src/constants/State';
 import type { Track, Progress, PlaybackState } from '../../src/interfaces';
 import { SetupNotCalledError } from './SetupNotCalledError';
-// @ts-ignore
 import shaka from 'shaka-player/dist/shaka-player.ui';
 
 export class Player {

--- a/web/TrackPlayer/Player.ts
+++ b/web/TrackPlayer/Player.ts
@@ -1,6 +1,8 @@
 import { State } from '../../src/constants/State';
 import type { Track, Progress, PlaybackState } from '../../src/interfaces';
 import { SetupNotCalledError } from './SetupNotCalledError';
+// @ts-ignore
+import shaka from 'shaka-player/dist/shaka-player.ui';
 
 export class Player {
   protected hasInitialized: boolean = false;
@@ -41,9 +43,6 @@ export class Player {
       // TODO: double check the structure of this error message
       throw { code: 'player_already_initialized', message: 'The player is not initialized. Call setupPlayer first.' };
     }
-
-    // @ts-ignore
-    const shaka = await import('shaka-player/dist/shaka-player.ui');
     // Install built-in polyfills to patch browser incompatibilities.
     shaka.polyfill.installAll();
     // Check to see if the browser supports the basic APIs Shaka needs.

--- a/web/shaka-player.d.ts
+++ b/web/shaka-player.d.ts
@@ -1,0 +1,3 @@
+declare module 'shaka-player/dist/shaka-player.ui' {
+  export = shaka;
+}


### PR DESCRIPTION
Let bundlers decide how to import the package instead of forcing a dynamic import.