### PR TITLE
fix(iOS): replicate add code to setQueue

### DIFF
--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -373,7 +373,16 @@ export async function setRate(rate: number): Promise<void> {
  * @see https://rntp.dev/docs/api/constants/repeat-mode
  */
 export async function setQueue(tracks: Track[]): Promise<void> {
-  return TrackPlayer.setQueue(tracks);
+  const resolvedTracks = (Array.isArray(tracks) ? tracks : [tracks]).map(
+    (track) => ({
+      ...track,
+      url: resolveImportedAssetOrPath(track.url),
+      artwork: resolveImportedAssetOrPath(track.artwork),
+    })
+  );
+  return resolvedTracks.length < 1
+    ? undefined
+    : TrackPlayer.setQueue(resolvedTracks);
 }
 
 /**


### PR DESCRIPTION
- replicating to `setQueue` the same that was done in `add` because it was crashing in iOS when passing a local file for artwork

this was the crash
<img width="1135" alt="Screenshot 2024-06-11 at 18 25 58" src="https://github.com/doublesymmetry/react-native-track-player/assets/25596926/7a4bdcb9-5355-4e81-b4a7-a76edc383b20">

this is my first ever contribution to an open source repository and I think I did what was in your guidelines, but let me know if I should have done something different, for the next time