### PR TITLE
docs: the current version of the hook usePlaybackState returns an object.

### DIFF
--- a/docs/docs/api/hooks.md
+++ b/docs/docs/api/hooks.md
@@ -85,7 +85,7 @@ import { usePlaybackState, State } from 'react-native-track-player';
 
 const MyComponent = () => {
   const playerState = usePlaybackState();
-  const isPlaying = playerState === State.Playing;
+  const isPlaying = playerState.state === State.Playing;
 
   return (
     <View>


### PR DESCRIPTION
So the comparison in the code example on `usePlaybackState` lacks the property name.