### PR TITLE
fix(example): Fixed example slider to include tap events and error

### DIFF
--- a/example/src/components/PlaybackError.tsx
+++ b/example/src/components/PlaybackError.tsx
@@ -14,6 +14,8 @@ export const PlaybackError: React.FC<{
 const styles = StyleSheet.create({
   container: {
     width: '100%',
+    marginVertical: 24,
+    alignSelf: 'center'
   },
   text: {
     color: 'red',

--- a/example/src/components/Progress.tsx
+++ b/example/src/components/Progress.tsx
@@ -17,6 +17,7 @@ export const Progress: React.FC<{ live?: boolean }> = ({ live }) => {
       ) : (
         <View>
           <Slider
+            tapToSeek
             style={{ ...styles.slider, width: progressBarWidth }}
             value={position}
             minimumValue={0}


### PR DESCRIPTION

Fixed the styling for the error in the example app and added tap event to Slider
<img width="305" alt="Screenshot 2024-09-22 at 21 01 29" src="https://github.com/user-attachments/assets/bd03342d-0865-4da0-a8a1-33b34a0246db">
