### PR TITLE
fix(android): avoid throwing

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/utils/BundleUtils.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/utils/BundleUtils.kt
@@ -16,7 +16,7 @@ object BundleUtils {
         val obj = data[key]
         if (obj is String) {
             // Remote or Local Uri
-            if (obj.trim { it <= ' ' }.isEmpty()) throw RuntimeException("$key: The URL cannot be empty")
+            if (obj.trim { it <= ' ' }.isEmpty()) return null
             return Uri.parse(obj as String?)
         } else if (obj is Bundle) {
             // require/import


### PR DESCRIPTION
`getUri` returns null when the key doesn't exist, but throws when it is empty string
https://github.com/doublesymmetry/react-native-track-player/blob/main/android/src/main/java/com/doublesymmetry/trackplayer/utils/BundleUtils.kt#L15

If the artwork is empty string instead of null, it will throw and prevent the whole audio to start.