### PR TITLE
fix(android): correct onBind method signature to match in MusicService.kt

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -761,7 +761,7 @@ class MusicService : HeadlessJsTaskService() {
     }
 
     @MainThread
-    override fun onBind(intent: Intent?): IBinder {
+    override fun onBind(intent: Intent): IBinder {
         return binder
     }
 


### PR DESCRIPTION
### Summary

This PR fixes a Kotlin compilation error in `MusicService.kt` related to the `onBind` method signature.

### Problem

The existing code attempted to override:

```kotlin
override fun onBind(intent: Intent?): IBinder
```

However, the Android Service class defines:
```
public abstract IBinder onBind(Intent intent)
```
Due to Kotlin's strict override checks, the mismatch causes:
```
'onBind' overrides nothing.
```

Fix
Updated the signature to match the exact expected method:

```kotlin
@MainThread
override fun onBind(intent: Intent): IBinder {
    return binder
}
```