### PR TITLE
fix(web): preserve playback rate across tracks

### DIFF
--- a/web/TrackPlayer/Player.ts
+++ b/web/TrackPlayer/Player.ts
@@ -147,6 +147,7 @@ export class Player {
 
   public setRate(rate: number) {
     if (!this.element) throw new SetupNotCalledError();
+    this.element.defaultPlaybackRate = rate;
     return this.element.playbackRate = rate;
   }
 


### PR DESCRIPTION
This changes the behavior on web to match that of mobile. When the playback rate has been changed, it stays the same for new tracks that are loaded.