### PR TITLE
fix(musicmodule.kt): pass non nullable Bundle

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -544,11 +544,13 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     fun getTrack(index: Int, callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
 
-        if (index >= 0 && index < musicService.tracks.size) {
-            callback.resolve(Arguments.fromBundle(musicService.tracks[index].originalItem))
-        } else {
+        if( index < 0 || index >= musicService.tracks.size) {
             callback.resolve(null)
+            return@launch
         }
+
+        val originalItem = musicService.tracks[index].originalItem
+        callback.resolve(if(originalItem == null) null else Arguments.fromBundle(originalItem))
     }
 
     @ReactMethod
@@ -582,12 +584,13 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     @ReactMethod
     fun getActiveTrack(callback: Promise) = scope.launch {
         if (verifyServiceBoundOrReject(callback)) return@launch
-        callback.resolve(
-            if (musicService.tracks.isEmpty()) null
-            else Arguments.fromBundle(
-                musicService.tracks[musicService.getCurrentTrackIndex()].originalItem
-            )
-        )
+        if(musicService.tracks.isEmpty()) {
+            callback.resolve(null)
+            return@launch
+        }
+
+        val activeTrack = musicService.tracks[musicService.getCurrentTrackIndex()].originalItem
+        callback.resolve(if(activeTrack == null) null else Arguments.fromBundle(activeTrack))
     }
 
     @ReactMethod


### PR DESCRIPTION
fix #2480

[This commit](https://github.com/facebook/react-native/commit/c8f01ffc3ea2271e166ea6b8fecf53aa950b4c42) made it to react native 0.80.0 and now arguments passed to `Arguments.fromBundle` has to be non nullable. However `originalItem` is nullable:
https://github.com/doublesymmetry/react-native-track-player/blob/e8701be9f7876ae3c80d7cfdfca7e90c40d6c389/android/src/main/java/com/doublesymmetry/trackplayer/model/Track.kt#L20
and is being passed as an argument to `Arguments.fromBundle`, so this need to be handled and is done in this PR
