### PR TITLE
fix(ios): better example for player setup

### DIFF
--- a/example/src/services/SetupService.ts
+++ b/example/src/services/SetupService.ts
@@ -11,18 +11,19 @@ export const DefaultAudioServiceBehaviour =
 const setupPlayer = async (
   options: Parameters<typeof TrackPlayer.setupPlayer>[0]
 ) => {
-  const setup = async () => {
+  while(1) {
     try {
       await TrackPlayer.setupPlayer(options);
     } catch (error) {
-      return (error as Error & { code?: string }).code;
+      if (error?.code === 'android_cannot_setup_player_in_background') {
+        // try again if app in the background, foreground needed to setup successfully
+        continue;
+      }
+
+      throw error;
     }
-  };
-  while ((await setup()) === 'android_cannot_setup_player_in_background') {
-    // A timeout will mostly only execute when the app is in the foreground,
-    // and even if we were in the background still, it will reject the promise
-    // and we'll try again:
-    await new Promise<void>((resolve) => setTimeout(resolve, 1));
+
+    break;
   }
 };
 


### PR DESCRIPTION
When building the Godcaster app we noticed that the track player would not load for iOS CarPlay when the phone screen was off. By eliminating `setTimeout` in loading code this allowed the app to load correctly while also still allowing Android to load properly too.

Note, I think this is also easier to read and follow.