### PR TITLE
feat(player): add default user-agent for Media3 requests

### DIFF
--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/players/components/MediaFactory.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/players/components/MediaFactory.kt
@@ -34,6 +34,10 @@ class MediaFactory (
     private val cache: SimpleCache?
 ) : MediaSource.Factory {
 
+    companion object {
+        private const val DEFAULT_USER_AGENT = "react-native-track-player/5.0.0"
+    }
+
     private val mediaFactory = DefaultMediaSourceFactory(context)
 
     override fun setDrmSessionManagerProvider(drmSessionManagerProvider: DrmSessionManagerProvider): MediaSource.Factory {
@@ -50,7 +54,7 @@ class MediaFactory (
 
     override fun createMediaSource(mediaItem: MediaItem): MediaSource {
 
-        val userAgent = mediaItem.mediaMetadata.extras?.getString("user-agent")
+        val userAgent = mediaItem.mediaMetadata.extras?.getString("user-agent") ?: DEFAULT_USER_AGENT
         val headers = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mediaItem.mediaMetadata.extras?.getSerializable("headers", HashMap::class.java)
         } else {


### PR DESCRIPTION
Added a custom user-agent string to prevent 403 errors when playing Live365 streams using Media3.

Resolves https://github.com/doublesymmetry/react-native-track-player/issues/2495.

## Issue
Some streams require user-agent to be defined. Such as
https://streaming.live365.com/a39417 & https://streaming.live365.com/a62429.
Starting those streams with new media3 implementation resulted in playback error 
```
{
    "message": "Source error",
    "code": "android-io-bad-http-status"
}
```
Tested in example app, on various emulators, physical devices and on different Android versions & Android Studio versions... Same issue everywhere.
`main` branch did work as expected, streams played in all scenarios.

After looking into it, server was throwing 403 - Forbidden for media3 implementation.

## Fix
Added default user-agent to comply with those restrictions.

Users are still able to override user-agent, by defining it inside track object.

Verified in example app, running on Motorola g34 5G, Android 14.
Example:
```
{
    "url": "https://das-edge11-live365-dal03.cdnstream.com/a39417",
    "title": "Radio Stream 1",
    "artist": "Not Working",
    "artwork": "https://rntp.dev/example/smooth-jazz-24-7.jpeg",
    "isLiveStream": true,
    "userAgent": "TestUserAgent"
  }
```