### PR TITLE
Feat/now playing metadata hook and event

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -51,6 +51,7 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val METADATA_TIMED_RECEIVED = "metadata-timed-received"
         const val METADATA_COMMON_RECEIVED = "metadata-common-received"
         const val METADATA_PAYLOAD_KEY = "metadata"
+        const val NOW_PLAYING_METADATA_CHANGED = "now-playing-metadata-changed"
 
         // Other
         const val PLAYER_ERROR = "player-error"

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -338,6 +338,13 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
         callback.resolve(null)
     }
 
+    override fun getNowPlayingMetadata(callback: Promise) = launchInScope {
+        if (verifyServiceBoundOrReject(callback)) return@launchInScope
+
+        val metadata = musicService.getNowPlayingMetadata()
+        callback.resolve(metadata?.let { Arguments.fromBundle(it) })
+    }
+    
     override fun removeUpcomingTracks(callback: Promise) = launchInScope {
         if (verifyServiceBoundOrReject(callback)) return@launchInScope
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -68,6 +68,7 @@ class MusicService : HeadlessJsMediaService() {
     private var playerCommands: Player.Commands? = null
     private var customLayout: List<CommandButton> = listOf()
     private var lastWake: Long = 0
+    private var nowPlayingMetadata: Bundle? = Bundle()
     var onStartCommandIntentValid: Boolean = true
 
     fun acquireWakeLock() {
@@ -500,6 +501,11 @@ class MusicService : HeadlessJsMediaService() {
         updateMetadataForTrack(player.currentIndex, bundle)
     }
 
+    @MainThread
+    fun getNowPlayingMetadata(): Bundle? {
+        return nowPlayingMetadata
+    }
+
     private fun emitPlaybackTrackChangedEvents(
         previousIndex: Int?,
         oldPosition: Double
@@ -628,6 +634,11 @@ class MusicService : HeadlessJsMediaService() {
                         putString("date", metadata.date)
                         putString("genre", metadata.genre)
                         emit(MusicEvents.PLAYBACK_METADATA, this)
+
+                        nowPlayingMetadata = this
+                        val eventPayload = Bundle()
+                        eventPayload.putBundle("metadata", this!!.clone() as Bundle)
+                        emit(MusicEvents.NOW_PLAYING_METADATA_CHANGED, eventPayload)
                     }
                 }
             }
@@ -640,6 +651,12 @@ class MusicService : HeadlessJsMediaService() {
                     putBundle(METADATA_PAYLOAD_KEY, data)
                 }
                 emit(MusicEvents.METADATA_COMMON_RECEIVED, bundle)
+                
+                nowPlayingMetadata = data
+                val eventPayload = Bundle()
+                eventPayload.putBundle("metadata", data!!.clone() as Bundle)
+                emit(MusicEvents.NOW_PLAYING_METADATA_CHANGED, eventPayload)
+                emit(MusicEvents.NOW_PLAYING_METADATA_CHANGED, eventPayload)
             }
         }
 

--- a/example/src/services/PlaybackService.ts
+++ b/example/src/services/PlaybackService.ts
@@ -76,4 +76,8 @@ export async function PlaybackService() {
   TrackPlayer.addEventListener(Event.MetadataCommonReceived, (event) => {
     console.log('Event.MetadataCommonReceived', event);
   });
+
+  TrackPlayer.addEventListener(Event.NowPlayingMetadataChanged, (event) => {
+    console.log('Event.NowPlayingMetadataChanged', event);
+  });
 }

--- a/ios/TrackPlayer.mm
+++ b/ios/TrackPlayer.mm
@@ -177,6 +177,10 @@ RCT_EXPORT_MODULE()
   [nativeTrackPlayer updateNowPlayingMetadataWithMetadata:metadata resolve:resolve reject:reject];
 }
 
+- (void)getNowPlayingMetadata:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+  [nativeTrackPlayer getNowPlayingMetadataWithResolve:resolve reject:reject];
+}
+
 - (void)updateOptions:(nonnull NSDictionary *)options resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
   [nativeTrackPlayer updateOptions:options resolver:resolve rejecter:reject];
 }

--- a/ios/Utils/EventType.swift
+++ b/ios/Utils/EventType.swift
@@ -24,6 +24,7 @@ enum EventType: String, CaseIterable {
     case MetadataChapterReceived = "metadata-chapter-received"
     case MetadataTimedReceived = "metadata-timed-received"
     case MetadataCommonReceived = "metadata-common-received"
+    case NowPlayingMetadataChanged = "now-playing-metadata-changed"
 
     static func allRawValues() -> [String] {
         return allCases.map { $0.rawValue }

--- a/src/NativeTrackPlayer.ts
+++ b/src/NativeTrackPlayer.ts
@@ -40,6 +40,7 @@ export interface Spec extends TurboModule {
     metadata: UnsafeObject
   ): Promise<void>;
   updateNowPlayingMetadata(metadata: UnsafeObject): Promise<void>;
+  getNowPlayingMetadata(): Promise<void>;
   setQueue(tracks: UnsafeObject[]): Promise<void>;
   getQueue(): Promise<UnsafeObject[]>;
   setRepeatMode(mode: number): Promise<number>;

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -125,7 +125,10 @@ export enum Event {
    * Fired when common (static) metadata is received.
    * See https://rntp.dev/docs/api/events#commonmetadatareceived
    **/
-  MetadataCommonReceived = 'metadata-common-received',
+  MetadataCommonReceived = 'metadata-common-received' /**
+   * Fired when metadata of active track has changed.
+   **/,
+  NowPlayingMetadataChanged = 'now-playing-metadata-changed',
   /**
    * Fired when an android connector connects to MusicService.
    * typical controllers are media notification and Android Auto.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './usePlayWhenReady';
 export * from './usePlaybackState';
 export * from './useProgress';
 export * from './useTrackPlayerEvents';
+export * from './useNowPlayingMetadata';

--- a/src/hooks/useNowPlayingMetadata.ts
+++ b/src/hooks/useNowPlayingMetadata.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+import { Event } from '../constants';
+import { useTrackPlayerEvents } from './useTrackPlayerEvents';
+import type { NowPlayingMetadata } from '../interfaces';
+import TrackPlayer from '..';
+
+export const useNowPlayingMetadata = (): NowPlayingMetadata | undefined => {
+  const [metadata, setMetadata] = useState<NowPlayingMetadata | undefined>();
+
+  useEffect(() => {
+    let unmounted = false;
+
+    if (unmounted) return;
+
+    TrackPlayer.getNowPlayingMetadata()
+      .then(setMetadata)
+      .catch(() => {
+        /** Only throws while you haven't yet setup, ignore failure. */
+      });
+
+    return () => {
+      unmounted = true;
+    };
+  }, []);
+
+  useTrackPlayerEvents([Event.NowPlayingMetadataChanged], (event) =>
+    setMetadata(event.metadata)
+  );
+
+  return metadata;
+};

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -8,6 +8,7 @@ import type {
   AndroidControllerConnectedEvent,
   AndroidControllerDisconnectedEvent,
 } from './ControllerConnectedEvent';
+import type { NowPlayingMetadataChangedEvent } from './NowPlayingMetadataChangedEvent';
 import type { PlaybackActiveTrackChangedEvent } from './PlaybackActiveTrackChangedEvent';
 import type { PlaybackErrorEvent } from './PlaybackErrorEvent';
 import type { PlaybackPlayWhenReadyChangedEvent } from './PlaybackPlayWhenReadyChangedEvent';
@@ -55,6 +56,7 @@ export type EventPayloadByEvent = {
   [Event.MetadataCommonReceived]: AudioCommonMetadataReceivedEvent;
   [Event.AndroidConnectorConnected]: AndroidControllerConnectedEvent;
   [Event.AndroidConnectorDisconnected]: AndroidControllerDisconnectedEvent;
+  [Event.NowPlayingMetadataChanged]: NowPlayingMetadataChangedEvent;
 };
 
 type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};

--- a/src/interfaces/events/NowPlayingMetadataChangedEvent.ts
+++ b/src/interfaces/events/NowPlayingMetadataChangedEvent.ts
@@ -1,0 +1,5 @@
+import type { NowPlayingMetadata } from '../NowPlayingMetadata';
+
+export interface NowPlayingMetadataChangedEvent {
+  metadata: NowPlayingMetadata;
+}

--- a/src/interfaces/events/index.ts
+++ b/src/interfaces/events/index.ts
@@ -13,3 +13,4 @@ export * from './RemotePlaySearchEvent';
 export * from './RemoteSeekEvent';
 export * from './RemoteSetRatingEvent';
 export * from './RemoteSkipEvent';
+export * from './NowPlayingMetadataChangedEvent';

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -241,6 +241,15 @@ export function updateNowPlayingMetadata(
   });
 }
 
+/**
+ * Gets the metadata content of the notification (Android) and the Now Playing Center (iOS).
+ */
+export async function getNowPlayingMetadata(): Promise<
+  NowPlayingMetadata | undefined
+> {
+  return (await TrackPlayer.getNowPlayingMetadata()) ?? undefined;
+}
+
 // MARK: - Player API
 
 /**


### PR DESCRIPTION
This PR resolves ongoing issue (https://github.com/doublesymmetry/react-native-track-player/issues/2158), from previous rntp versions, but is adjusted to upcoming version.

I've created PR for fixing this last year, you can check full description here:
https://github.com/doublesymmetry/react-native-track-player/pull/2250
PR was closed due to it being stale, @dcvz not having time to review, most likely.

- I've tested this in example app
- In App.js, on mount, I've created a 10s timeout with callback that updates now playing metadata
- As you'll see in video recording, lock screen metadata is updated, but `activeTrack` object is not
- We want (I guess) 1:1 link to now playing metadata in-app, for updating track info & artwork

Video recordings before and after this fix:
<table>
<tr>
<td>iOS before</td><td>Android before</td></tr>
<tr>
<td>

https://github.com/user-attachments/assets/1d7862e1-7a8e-4a78-9649-87333083d2b6


</td><td>

https://github.com/user-attachments/assets/9462c8d4-5fd2-4ce0-8ba2-1fce7def291e


</td></tr>
</tr>
<tr>
<td>iOS after</td><td>Android after</></tr><tr>
<td>

https://github.com/user-attachments/assets/78a3d339-c35a-44d7-b812-6f0608cda3ad


</td><td>

https://github.com/user-attachments/assets/4946fc21-61cf-43c0-9b62-1874bcd064d5


</td>
</tr>

</table>