### PR TITLE
feat (ios & android): metadata update fixes and improvements

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/model/Track.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/model/Track.kt
@@ -28,7 +28,24 @@ class Track
 
     override fun setMetadata(context: Context, bundle: Bundle?, ratingType: Int) {
         super.setMetadata(context, bundle, ratingType)
-        originalItem.putAll(bundle)
+        // Only update originalItem with fields that were actually provided
+        bundle?.keySet()?.forEach { key ->
+            originalItem.putAll(Bundle().apply {
+                putValue(key, bundle.get(key))
+            })
+        }
+    }
+
+    private fun Bundle.putValue(key: String, value: Any?) {
+        when (value) {
+            null -> remove(key)
+            is String -> putString(key, value)
+            is Int -> putInt(key, value)
+            is Double -> putDouble(key, value)
+            is Boolean -> putBoolean(key, value)
+            is Bundle -> putBundle(key, value)
+            // Add other types as needed
+        }
     }
 
     fun toAudioItem(): TrackAudioItem {

--- a/android/src/main/java/com/doublesymmetry/trackplayer/model/TrackMetadata.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/model/TrackMetadata.kt
@@ -19,20 +19,35 @@ abstract class TrackMetadata {
     var mediaId: String? = null
 
     open fun setMetadata(context: Context, bundle: Bundle?, ratingType: Int) {
-        artwork = BundleUtils.getUri(context, bundle, "artwork")
-        title = bundle!!.getString("title")
-        artist = bundle.getString("artist")
-        album = bundle.getString("album")
-        date = bundle.getString("date")
-        genre = bundle.getString("genre")
-        mediaId = bundle.getString("mediaId")
-
-        duration = if (bundle.containsKey("duration")) {
-            bundle.getDouble("duration").toMilliseconds()
-        } else {
-            null
+        // Special handling for artwork:
+        // - If undefined/null in bundle - keep existing artwork
+        // - If empty string - explicitly clear artwork
+        // - If valid URI - update artwork
+        if (bundle?.containsKey("artwork") == true) {
+            val artworkStr = bundle.getString("artwork")
+            artwork = if (artworkStr?.isEmpty() == true) {
+                null // Clear artwork for empty string
+            } else {
+                BundleUtils.getUri(context, bundle, "artwork") ?: artwork // Keep existing if new is invalid
+            }
         }
 
-        rating = BundleUtils.getRating(bundle, "rating", ratingType)
+        // For all other fields, only update if provided in bundle
+        bundle?.getString("title")?.let { title = it }
+        bundle?.getString("artist")?.let { artist = it }
+        bundle?.getString("album")?.let { album = it }
+        bundle?.getString("date")?.let { date = it }
+        bundle?.getString("genre")?.let { genre = it }
+        bundle?.getString("mediaId")?.let { mediaId = it }
+
+        // Update duration if provided
+        if (bundle?.containsKey("duration") == true) {
+            duration = bundle.getDouble("duration").toMilliseconds()
+        }
+
+        // Update rating if provided
+        if (bundle?.containsKey("rating") == true) {
+            rating = BundleUtils.getRating(bundle, "rating", ratingType)
+        }
     }
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -52,6 +52,7 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val METADATA_COMMON_RECEIVED = "metadata-common-received"
         const val METADATA_PAYLOAD_KEY = "metadata"
         const val TRACK_METADATA_UPDATED = "track-metadata-updated"
+        const val NOW_PLAYING_METADATA_UPDATED = "now-playing-metadata-updated"
 
         // Other
         const val PLAYER_ERROR = "player-error"

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -51,6 +51,7 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val METADATA_TIMED_RECEIVED = "metadata-timed-received"
         const val METADATA_COMMON_RECEIVED = "metadata-common-received"
         const val METADATA_PAYLOAD_KEY = "metadata"
+        const val TRACK_METADATA_UPDATED = "track-metadata-updated"
 
         // Other
         const val PLAYER_ERROR = "player-error"

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -492,6 +492,12 @@ class MusicService : HeadlessJsMediaService() {
             currentTrack.setMetadata(reactContext, bundle, 0)
 
             player.replaceItem(index, currentTrack.toAudioItem())
+
+            val eventBundle = Bundle().apply {
+                putInt("index", index)
+                putBundle("track", currentTrack.originalItem)
+            }
+            emit(MusicEvents.TRACK_METADATA_UPDATED, eventBundle)
         }
     }
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -486,7 +486,7 @@ class MusicService : HeadlessJsMediaService() {
         return bundle
     }
 
-    // Updates current track in player, as well as Now Playing information in lock screen notification.
+    // Updates current track in player, as well as now playing notification.
     @MainThread
     fun updateMetadataForTrack(index: Int, bundle: Bundle) {
         tracks[index].let { currentTrack ->
@@ -502,7 +502,7 @@ class MusicService : HeadlessJsMediaService() {
         }
     }
 
-    // Updates only Now Playing information in lock screen notification, without affecting stored track in player.
+    // Updates only now playing notification, without affecting stored track in player.
     @MainThread
     fun updateNowPlayingMetadata(bundle: Bundle) {
         val nowPlayingTrack = currentTrack ?: return

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -486,6 +486,7 @@ class MusicService : HeadlessJsMediaService() {
         return bundle
     }
 
+    // Updates current track in player, as well as Now Playing information in lock screen notification.
     @MainThread
     fun updateMetadataForTrack(index: Int, bundle: Bundle) {
         tracks[index].let { currentTrack ->
@@ -501,13 +502,19 @@ class MusicService : HeadlessJsMediaService() {
         }
     }
 
+    // Updates only Now Playing information in lock screen notification, without affecting stored track in player.
     @MainThread
     fun updateNowPlayingMetadata(bundle: Bundle) {
         val nowPlayingTrack = currentTrack ?: return
-      
+
         nowPlayingTrack?.setMetadata(reactContext, bundle, 0)
         player.replaceItem(player.currentIndex, nowPlayingTrack.toAudioItem())
 
+        val eventBundle = Bundle().apply {
+            putInt("index", player.currentIndex)
+            putBundle("track", nowPlayingTrack.originalItem)
+        }
+        emit(MusicEvents.NOW_PLAYING_METADATA_UPDATED, eventBundle)
     }
 
     private fun emitPlaybackTrackChangedEvents(

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -503,7 +503,11 @@ class MusicService : HeadlessJsMediaService() {
 
     @MainThread
     fun updateNowPlayingMetadata(bundle: Bundle) {
-        updateMetadataForTrack(player.currentIndex, bundle)
+        val nowPlayingTrack = currentTrack ?: return
+      
+        nowPlayingTrack?.setMetadata(reactContext, bundle, 0)
+        player.replaceItem(player.currentIndex, nowPlayingTrack.toAudioItem())
+
     }
 
     private fun emitPlaybackTrackChangedEvents(

--- a/docs/docs/api/events.md
+++ b/docs/docs/api/events.md
@@ -203,3 +203,20 @@ Fired when a track's metadata has been updated using `updateMetadataForTrack`. C
 | ----- | ---- | ----------- |
 | index | `number` | The index of the track that was updated |
 | track | `Track` | The track object with updated metadata |
+
+### `TrackMetadataUpdated`
+Fired when a track's metadata has been updated using `updateMetadataForTrack`. Contains information about the track that was updated.
+
+| Param | Type | Description |
+| ----- | ---- | ----------- |
+| index | `number` | The index of the track that was updated |
+| track | `Track` | The track object with updated metadata |
+
+### `NowPlayingMetadataUpdated`
+
+Fired when a track's metadata has been updated using `updateNowPlayingMetadata`. Contains information about the track that was updated.
+
+| Param | Type     | Description                             |
+| ----- | -------- | --------------------------------------- |
+| index | `number` | The index of the track that was updated |
+| track | `Track`  | The track object with updated metadata  |

--- a/docs/docs/api/events.md
+++ b/docs/docs/api/events.md
@@ -204,14 +204,6 @@ Fired when a track's metadata has been updated using `updateMetadataForTrack`. C
 | index | `number` | The index of the track that was updated |
 | track | `Track` | The track object with updated metadata |
 
-### `TrackMetadataUpdated`
-Fired when a track's metadata has been updated using `updateMetadataForTrack`. Contains information about the track that was updated.
-
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-| index | `number` | The index of the track that was updated |
-| track | `Track` | The track object with updated metadata |
-
 ### `NowPlayingMetadataUpdated`
 
 Fired when a track's metadata has been updated using `updateNowPlayingMetadata`. Contains information about the track that was updated.

--- a/docs/docs/api/events.md
+++ b/docs/docs/api/events.md
@@ -195,3 +195,11 @@ Received data will be [`AudioMetadataReceivedEvent`](./api/objects/metadata.md).
 Fired when the current track receives metadata encoded in - chapter overview data. Usually received at start.
 
 Received data will be [`AudioMetadataReceivedEvent`](./api/objects/metadata.md).
+
+### `TrackMetadataUpdated`
+Fired when a track's metadata has been updated using `updateMetadataForTrack`. Contains information about the track that was updated.
+
+| Param | Type | Description |
+| ----- | ---- | ----------- |
+| index | `number` | The index of the track that was updated |
+| track | `Track` | The track object with updated metadata |

--- a/docs/versioned_docs/version-5.0/api/hooks.md
+++ b/docs/versioned_docs/version-5.0/api/hooks.md
@@ -18,13 +18,10 @@ import { Text, View } from 'react-native';
 import { useTrackPlayerEvents, Event, State } from 'react-native-track-player';
 
 // Subscribing to the following events inside MyComponent
-const events = [
-  Event.PlaybackState,
-  Event.PlaybackError,
-];
+const events = [Event.PlaybackState, Event.PlaybackError];
 
 const MyComponent = () => {
-  const [playerState, setPlayerState] = useState(null)
+  const [playerState, setPlayerState] = useState(null);
 
   useTrackPlayerEvents(events, (event) => {
     if (event.type === Event.PlaybackError) {
@@ -47,11 +44,11 @@ const MyComponent = () => {
 
 ## `useProgress`
 
-| State            | Type     | Description                      |
-| ---------------- | -------- | -------------------------------- |
-| position         | `number` | The current position in seconds  |
-| buffered         | `number` | The buffered position in seconds |
-| duration         | `number` | The duration in seconds          |
+| State    | Type     | Description                      |
+| -------- | -------- | -------------------------------- |
+| position | `number` | The current position in seconds  |
+| buffered | `number` | The buffered position in seconds |
+| duration | `number` | The duration in seconds          |
 
 `useProgress` accepts an interval to set the rate (in miliseconds) to poll the track player's progress. The default value is `1000` or every second.
 
@@ -61,15 +58,19 @@ import { Text, View } from 'react-native';
 import { useProgress } from 'react-native-track-player';
 
 const MyComponent = () => {
-  const { position, buffered, duration } = useProgress()
+  const { position, buffered, duration } = useProgress();
 
   return (
     <View>
-      <Text>Track progress: {position} seconds out of {duration} total</Text>
-      <Text>Buffered progress: {buffered} seconds buffered out of {duration} total</Text>
+      <Text>
+        Track progress: {position} seconds out of {duration} total
+      </Text>
+      <Text>
+        Buffered progress: {buffered} seconds buffered out of {duration} total
+      </Text>
     </View>
-  )
-}
+  );
+};
 ```
 
 ## `usePlaybackState`
@@ -102,4 +103,9 @@ A hook which returns the up to date state of `TrackPlayer.getPlayWhenReady()`.
 ## `useActiveTrack`
 
 A hook which keeps track of the currently active track using
-`TrackPlayer.getActiveTrack()` and `Event.PlaybackActiveTrackChanged`.
+`TrackPlayer.getActiveTrack()`, `Event.PlaybackActiveTrackChanged` and `Event.TrackMetadataUpdated`.
+
+## `useNowPlayingMetadata`
+
+A hook which keeps track of active now playing metadata in notification (Android) and the Now Playing Center (iOS) using
+`TrackPlayer.getActiveTrack()`, `Event.NowPlayingMetadataUpdated` and `Event.TrackMetadataUpdated`.

--- a/example/src/components/ActionSheet.tsx
+++ b/example/src/components/ActionSheet.tsx
@@ -1,14 +1,35 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Spacer } from './Spacer';
 import { Button } from './Button';
 import TrackPlayer from 'react-native-track-player';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { Image } from 'react-native';
 
+const ARTWORK_URLS = [
+  'https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d',
+  'https://images.unsplash.com/photo-1521747116042-5a810fda9664',
+  'https://images.unsplash.com/photo-1516117172878-fd2c41f4a759',
+  'https://images.unsplash.com/photo-1532009324734-20a7a5813719',
+  'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e',
+  'https://images.unsplash.com/photo-1508780709619-79562169bc64',
+  'https://images.unsplash.com/photo-1494790108377-be9c29b29330',
+  'https://images.unsplash.com/photo-1541696432-82c6da8ce7bf',
+  'https://images.unsplash.com/photo-1517841905240-472988babdf9',
+  'https://images.unsplash.com/photo-1524504388940-b1c1722653e1',
+];
+
+const getRandomArtwork = () => {
+  const randomIndex = Math.floor(Math.random() * ARTWORK_URLS.length);
+  return ARTWORK_URLS[randomIndex];
+};
+
+// Merges current metadata with random title & artwork.
+// artist remains unchanged, because no artist value is provided.
 const onUpdateNotificationMetadata = async () => {
   const randomTitle = Math.random().toString(36).substring(7);
   await TrackPlayer.updateNowPlayingMetadata({
     title: `Random: ${randomTitle}`,
-    artwork: `https://random.imagecdn.app/800/800?dummy=${Date.now()}`,
+    artwork: getRandomArtwork(),
   });
 };
 
@@ -18,8 +39,19 @@ const onUpdateCurrentTrackMetadata = async () => {
     const randomTitle = Math.random().toString(36).substring(7);
     await TrackPlayer.updateMetadataForTrack(currentTrackIndex, {
       title: `Random: ${randomTitle}`,
-      artwork: `https://random.imagecdn.app/800/800?dummy=${Date.now()}`,
+      artwork: getRandomArtwork(),
       duration: Math.floor(Math.random()),
+    });
+  }
+};
+
+// Removes artwork and artist for the current track, by setting them to empty strings.
+const onRemoveArtworkAndArtist = async () => {
+  const currentTrackIndex = await TrackPlayer.getActiveTrackIndex();
+  if (currentTrackIndex !== undefined) {
+    await TrackPlayer.updateMetadataForTrack(currentTrackIndex, {
+      artwork: '',
+      artist: '',
     });
   }
 };
@@ -29,17 +61,35 @@ const onReset = async () => {
 };
 
 export const ActionSheet: React.FC = () => {
+  useEffect(() => {
+    const preloadImages = async () => {
+      try {
+        const preloadPromises = ARTWORK_URLS.map((url) => Image.prefetch(url));
+        await Promise.all(preloadPromises);
+      } catch (error) {
+        console.error('Error preloading images:', error);
+      }
+    };
+
+    preloadImages();
+  }, []);
+
   return (
     <BottomSheetScrollView>
       <Spacer />
       <Button
-        title={'Update Notification Metadata Randomly'}
+        title={'Update Now Playing Metadata Randomly'}
         onPress={onUpdateNotificationMetadata}
         type={'primary'}
       />
       <Button
         title={'Update Current Track Metadata Randomly'}
         onPress={onUpdateCurrentTrackMetadata}
+        type={'primary'}
+      />
+      <Button
+        title={'Remove Artwork And Artist For Current Track'}
+        onPress={onRemoveArtworkAndArtist}
         type={'primary'}
       />
       <Button title={'Reset'} onPress={onReset} type={'primary'} />

--- a/example/src/components/ActionSheet.tsx
+++ b/example/src/components/ActionSheet.tsx
@@ -23,8 +23,12 @@ const getRandomArtwork = () => {
   return ARTWORK_URLS[randomIndex];
 };
 
-// Merges current metadata with random title & artwork.
-// artist remains unchanged, because no artist value is provided.
+/**
+ * Merges current now playing metadata with random title & artwork.
+ * artist remains unchanged, because no artist value is provided.
+ * This function updates now playing metadata, without changing
+ * the underlying track object & its metadata.
+ */
 const onUpdateNotificationMetadata = async () => {
   const randomTitle = Math.random().toString(36).substring(7);
   await TrackPlayer.updateNowPlayingMetadata({
@@ -33,6 +37,12 @@ const onUpdateNotificationMetadata = async () => {
   });
 };
 
+/**
+ * Merges current metadata with random title, artwork and duration.
+ * artist remains unchanged, because no artist value is provided.
+ * This function updates the stored metadata for the current track, as
+ * well as now playing metadata.
+ */
 const onUpdateCurrentTrackMetadata = async () => {
   const currentTrackIndex = await TrackPlayer.getActiveTrackIndex();
   if (currentTrackIndex !== undefined) {
@@ -45,7 +55,11 @@ const onUpdateCurrentTrackMetadata = async () => {
   }
 };
 
-// Removes artwork and artist for the current track, by setting them to empty strings.
+/**
+ * Removes artwork and artist for the current track, by setting them to empty strings.
+ * This function updates the stored metadata for the current track, as
+ * well as now playing metadata.
+ */
 const onRemoveArtworkAndArtist = async () => {
   const currentTrackIndex = await TrackPlayer.getActiveTrackIndex();
   if (currentTrackIndex !== undefined) {

--- a/example/src/services/PlaybackService.ts
+++ b/example/src/services/PlaybackService.ts
@@ -80,4 +80,8 @@ export async function PlaybackService() {
   TrackPlayer.addEventListener(Event.TrackMetadataUpdated, (event) => {
     console.log('Event.TrackMetadataUpdated', event);
   });
+
+  TrackPlayer.addEventListener(Event.NowPlayingMetadataUpdated, (event) => {
+    console.log('Event.NowPlayingMetadataUpdated', event);
+  });
 }

--- a/example/src/services/PlaybackService.ts
+++ b/example/src/services/PlaybackService.ts
@@ -76,4 +76,8 @@ export async function PlaybackService() {
   TrackPlayer.addEventListener(Event.MetadataCommonReceived, (event) => {
     console.log('Event.MetadataCommonReceived', event);
   });
+
+  TrackPlayer.addEventListener(Event.TrackMetadataUpdated, (event) => {
+    console.log('Event.TrackMetadataUpdated', event);
+  });
 }

--- a/ios/TrackPlayer.swift
+++ b/ios/TrackPlayer.swift
@@ -664,6 +664,12 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
             Metadata.update(for: player, with: metadata)
         }
 
+        // Emit metadata updated event with the full track data
+        emit(event: EventType.TrackMetadataUpdated, body: [
+            "index": trackIndex,
+            "track": track.toObject()
+        ])
+
         resolve(NSNull())
     }
 
@@ -671,8 +677,7 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
     public func updateNowPlayingMetadata(metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if (rejectWhenNotInitialized(reject: reject)) { return }
 
-        Metadata.update(for: player, with: metadata)
-        resolve(NSNull())
+        updateMetadata(for: player.currentIndex, metadata: metadata, resolve: resolve, reject: reject)
     }
 
     private func getPlaybackStateErrorKeyValues() -> Dictionary<String, Any> {
@@ -726,6 +731,7 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
 
     func handleAudioPlayerCommonMetadataReceived(metadata: [AVMetadataItem]) {
         let commonMetadata = MetadataAdapter.convertToCommonMetadata(metadata: metadata, skipRaw: true)
+        NSLog("commonMetadata: %@", metadata)
         emit(event: EventType.MetadataCommonReceived, body: ["metadata": commonMetadata])
     }
 

--- a/ios/TrackPlayer.swift
+++ b/ios/TrackPlayer.swift
@@ -652,7 +652,7 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
         resolve(getPlaybackStateBodyKeyValues(state: player.playerState))
     }
 
-    // Updates current track in player, as well as Now Playing information in Notification Center.
+    // Updates current track in player, as well as Now Playing information in the Now Playing Center.
     @objc
     public func updateMetadata(for trackIndex: Int, metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if (rejectWhenNotInitialized(reject: reject)) { return }
@@ -674,7 +674,7 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
         resolve(NSNull())
     }
 
-    // Updates only Now Playing information in Notification Center, without affecting stored track in player.
+    // Updates only Now Playing information in the Now Playing Center, without affecting stored track in player.
     @objc
     public func updateNowPlayingMetadata(metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if (rejectWhenNotInitialized(reject: reject)) { return }

--- a/ios/TrackPlayer.swift
+++ b/ios/TrackPlayer.swift
@@ -677,7 +677,8 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
     public func updateNowPlayingMetadata(metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if (rejectWhenNotInitialized(reject: reject)) { return }
 
-        updateMetadata(for: player.currentIndex, metadata: metadata, resolve: resolve, reject: reject)
+        Metadata.update(for: player, with: metadata)
+        resolve(NSNull())
     }
 
     private func getPlaybackStateErrorKeyValues() -> Dictionary<String, Any> {

--- a/ios/TrackPlayer.swift
+++ b/ios/TrackPlayer.swift
@@ -652,10 +652,12 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
         resolve(getPlaybackStateBodyKeyValues(state: player.playerState))
     }
 
+    // Updates current track in player, as well as Now Playing information in Notification Center.
     @objc
     public func updateMetadata(for trackIndex: Int, metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if (rejectWhenNotInitialized(reject: reject)) { return }
         if (rejectWhenTrackIndexOutOfBounds(index: trackIndex, reject: reject)) { return }
+
 
         let track : Track = player.items[trackIndex] as! Track;
         track.updateMetadata(dictionary: metadata)
@@ -664,7 +666,6 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
             Metadata.update(for: player, with: metadata)
         }
 
-        // Emit metadata updated event with the full track data
         emit(event: EventType.TrackMetadataUpdated, body: [
             "index": trackIndex,
             "track": track.toObject()
@@ -673,11 +674,27 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
         resolve(NSNull())
     }
 
+    // Updates only Now Playing information in Notification Center, without affecting stored track in player.
     @objc
     public func updateNowPlayingMetadata(metadata: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         if (rejectWhenNotInitialized(reject: reject)) { return }
+        if (rejectWhenTrackIndexOutOfBounds(index: player.currentIndex, reject: reject)) { return }
 
+        let currentTrack = player.items[player.currentIndex] as! Track
+        
+        // Create a temporary copy of the current track to get merged metadata
+        let tempTrack = Track(dictionary: currentTrack.toObject())
+        tempTrack?.updateMetadata(dictionary: metadata)
+        
         Metadata.update(for: player, with: metadata)
+
+        if let tempTrack = tempTrack {
+            emit(event: EventType.NowPlayingMetadataUpdated, body: [
+                "index": player.currentIndex,
+                "track": tempTrack.toObject()
+            ])
+        }
+
         resolve(NSNull())
     }
 

--- a/ios/Utils/EventType.swift
+++ b/ios/Utils/EventType.swift
@@ -25,6 +25,7 @@ enum EventType: String, CaseIterable {
     case MetadataTimedReceived = "metadata-timed-received"
     case MetadataCommonReceived = "metadata-common-received"
     case TrackMetadataUpdated = "track-metadata-updated"
+    case NowPlayingMetadataUpdated = "now-playing-metadata-updated"
 
     static func allRawValues() -> [String] {
         return allCases.map { $0.rawValue }

--- a/ios/Utils/EventType.swift
+++ b/ios/Utils/EventType.swift
@@ -24,6 +24,7 @@ enum EventType: String, CaseIterable {
     case MetadataChapterReceived = "metadata-chapter-received"
     case MetadataTimedReceived = "metadata-timed-received"
     case MetadataCommonReceived = "metadata-common-received"
+    case TrackMetadataUpdated = "track-metadata-updated"
 
     static func allRawValues() -> [String] {
         return allCases.map { $0.rawValue }

--- a/ios/Utils/Metadata.swift
+++ b/ios/Utils/Metadata.swift
@@ -13,49 +13,70 @@ import SwiftAudioEx
 struct Metadata {
     private static var currentImageTask: URLSessionDataTask?
 
+    // Patches existing active track metadata with given new metadata updates.
     static func update(for player: AudioPlayer, with metadata: [String: Any]) {
         currentImageTask?.cancel()
         var ret: [NowPlayingInfoKeyValue] = []
         
-        if let title = metadata["title"] as? String {
+        // Get current track for existing metadata
+        guard let currentIndex = (player as? QueuedAudioPlayer)?.currentIndex,
+              currentIndex >= 0,
+              let items = (player as? QueuedAudioPlayer)?.items,
+              currentIndex < items.count,
+              let currentTrack = items[currentIndex] as? Track else {
+            return
+        }
+        
+        let title = metadata["title"] as? String ?? currentTrack.title
+        if let title = title {
             ret.append(MediaItemProperty.title(title))
         }
         
-        if let artist = metadata["artist"] as? String {
+        let artist = metadata["artist"] as? String ?? currentTrack.artist
+        if let artist = artist {
             ret.append(MediaItemProperty.artist(artist))
         }
         
-        if let album = metadata["album"] as? String {
+        let album = metadata["album"] as? String ?? currentTrack.album
+        if let album = album {
             ret.append(MediaItemProperty.albumTitle(album))
         }
         
-        if let duration = metadata["duration"] as? Double {
+        let duration = metadata["duration"] as? Double ?? currentTrack.duration
+        if let duration = duration {
             ret.append(MediaItemProperty.duration(duration))
         }
         
-        if let elapsedTime = metadata["elapsedTime"] as? Double {
+        if let elapsedTime = metadata["elapsedTime"] as? Double ?? (player.currentTime != 0 ? player.currentTime : nil) {
             ret.append(NowPlayingInfoProperty.elapsedPlaybackTime(elapsedTime))
         }
 
-        if let isLiveStream = metadata["isLiveStream"] as? Bool {
+        let isLiveStream = metadata["isLiveStream"] as? Bool ?? currentTrack.isLiveStream
+        if let isLiveStream = isLiveStream {
             ret.append(NowPlayingInfoProperty.isLiveStream(isLiveStream))
         }
         
         player.nowPlayingInfoController.set(keyValues: ret)
         
-        if let artworkURL = MediaURL(object: metadata["artwork"]) {
-            currentImageTask = URLSession.shared.dataTask(with: artworkURL.value, completionHandler: { [weak player] (data, _, error) in
-                if let data = data, let image = UIImage(data: data), error == nil {
-                    let artwork = MPMediaItemArtwork(boundsSize: image.size, requestHandler: { (size) -> UIImage in
-                        return image
-                    })
-                    player?.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(artwork))
-                }
-            })
-            
-            currentImageTask?.resume()
-        } else {
-            player.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(nil))
+        // Handle artwork updates:
+        // - If artwork is undefined/null, keep existing artwork.
+        // - If artwork is an empty string, explicitly, remove artwork.
+        // - If artwork is defined and valid, update artwork.
+        if let artworkValue = metadata["artwork"] as? String {
+            if artworkValue.isEmpty {
+                player.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(nil))
+            } else if let artworkURL = MediaURL(object: artworkValue) {
+                currentImageTask = URLSession.shared.dataTask(with: artworkURL.value, completionHandler: { [weak player] (data, _, error) in
+                    if let data = data, let image = UIImage(data: data), error == nil {
+                        let artwork = MPMediaItemArtwork(boundsSize: image.size, requestHandler: { (size) -> UIImage in
+                            return image
+                        })
+                        player?.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(artwork))
+                    }
+                })
+                
+                currentImageTask?.resume()
+            }
         }
     }
 }

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -127,6 +127,11 @@ export enum Event {
    **/
   MetadataCommonReceived = 'metadata-common-received',
   /**
+   * Fired when common (static) metadata is received.
+   * See https://rntp.dev/docs/api/events#commonmetadatareceived
+   **/
+  TrackMetadataUpdated = 'track-metadata-updated',
+  /**
    * Fired when an android connector connects to MusicService.
    * typical controllers are media notification and Android Auto.
    **/

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -127,8 +127,8 @@ export enum Event {
    **/
   MetadataCommonReceived = 'metadata-common-received',
   /**
-   * Fired when common (static) metadata is received.
-   * See https://rntp.dev/docs/api/events#commonmetadatareceived
+   * Fired after calling `TrackPlayer.updateMetadata`.
+   * See https://rntp.dev/docs/api/events#trackmetadataupdated
    **/
   TrackMetadataUpdated = 'track-metadata-updated',
   /**

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -132,6 +132,11 @@ export enum Event {
    **/
   TrackMetadataUpdated = 'track-metadata-updated',
   /**
+   * Fired after calling `TrackPlayer.updateNowPlayingMetadata`.
+   * See https://rntp.dev/docs/api/events#nowplayingmetadataupdated
+   **/
+  NowPlayingMetadataUpdated = 'now-playing-metadata-updated',
+  /**
    * Fired when an android connector connects to MusicService.
    * typical controllers are media notification and Android Auto.
    **/

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './usePlayWhenReady';
 export * from './usePlaybackState';
 export * from './useProgress';
 export * from './useTrackPlayerEvents';
+export * from './useNowPlayingMetadata';

--- a/src/hooks/useActiveTrack.ts
+++ b/src/hooks/useActiveTrack.ts
@@ -26,9 +26,23 @@ export const useActiveTrack = (): Track | undefined => {
   }, []);
 
   useTrackPlayerEvents(
-    [Event.PlaybackActiveTrackChanged],
-    async ({ track: newTrack }) => {
-      setTrack(newTrack ?? undefined);
+    [Event.PlaybackActiveTrackChanged, Event.MetadataCommonReceived],
+    async (event) => {
+      if (event.type === Event.PlaybackActiveTrackChanged) {
+        setTrack(event.track ?? undefined);
+      } else {
+        setTrack((prevTrack) => {
+          if (!prevTrack) {
+            return undefined;
+          }
+
+          return {
+            ...prevTrack,
+            ...event.metadata,
+            artwork: event.metadata?.artworkUri,
+          };
+        });
+      }
     }
   );
 

--- a/src/hooks/useActiveTrack.ts
+++ b/src/hooks/useActiveTrack.ts
@@ -26,22 +26,19 @@ export const useActiveTrack = (): Track | undefined => {
   }, []);
 
   useTrackPlayerEvents(
-    [Event.PlaybackActiveTrackChanged, Event.MetadataCommonReceived],
+    [Event.PlaybackActiveTrackChanged, Event.TrackMetadataUpdated],
     async (event) => {
       if (event.type === Event.PlaybackActiveTrackChanged) {
         setTrack(event.track ?? undefined);
-      } else {
-        setTrack((prevTrack) => {
-          if (!prevTrack) {
-            return undefined;
-          }
+        return;
+      }
 
-          return {
-            ...prevTrack,
-            ...event.metadata,
-            artwork: event.metadata?.artworkUri,
-          };
-        });
+      if (
+        event.type === Event.TrackMetadataUpdated &&
+        track?.url === event.track?.url
+      ) {
+        // Update the active track if the updated track is the current active one
+        setTrack(event.track);
       }
     }
   );

--- a/src/hooks/useNowPlayingMetadata.ts
+++ b/src/hooks/useNowPlayingMetadata.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react';
+
+import { getActiveTrack } from '../trackPlayer';
+import { Event } from '../constants';
+import { useTrackPlayerEvents } from './useTrackPlayerEvents';
+import type { NowPlayingMetadata, Track } from '../interfaces';
+
+const extractNowPlayingMetadata = (
+  track: Track | undefined
+): NowPlayingMetadata | undefined => {
+  if (!track) return undefined;
+
+  return {
+    title: track.title,
+    album: track.album,
+    artist: track.artist,
+    duration: track.duration,
+    artwork: track.artwork,
+    description: track.description,
+    mediaId: track.mediaId,
+    genre: track.genre,
+    date: track.date,
+    rating: track.rating,
+    isLiveStream: track.isLiveStream,
+    elapsedTime: track.elapsedTime,
+  };
+};
+
+export const useNowPlayingMetadata = (): NowPlayingMetadata | undefined => {
+  const [nowPlayingMetadata, setNowPlayingMetadata] = useState<
+    NowPlayingMetadata | undefined
+  >();
+
+  // Sets the initial index (if still undefined)
+  useEffect(() => {
+    let unmounted = false;
+    getActiveTrack()
+      .then((initialTrack) => {
+        if (unmounted) return;
+        setNowPlayingMetadata(
+          (currentTrack) =>
+            currentTrack ?? extractNowPlayingMetadata(initialTrack) ?? undefined
+        );
+      })
+      .catch(() => {
+        // throws when you haven't yet setup, which is fine because it also
+        // means there's no active track
+      });
+    return () => {
+      unmounted = true;
+    };
+  }, []);
+
+  useTrackPlayerEvents(
+    [
+      Event.PlaybackActiveTrackChanged,
+      Event.NowPlayingMetadataUpdated,
+      Event.TrackMetadataUpdated,
+    ],
+    async (event) =>
+      setNowPlayingMetadata(extractNowPlayingMetadata(event.track) ?? undefined)
+  );
+
+  return nowPlayingMetadata;
+};

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -23,6 +23,7 @@ import type { RemotePlaySearchEvent } from './RemotePlaySearchEvent';
 import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
 import type { RemoteSkipEvent } from './RemoteSkipEvent';
+import type { TrackMetadataUpdatedEvent } from './TrackMetadataUpdatedEvent';
 
 export type EventPayloadByEvent = {
   [Event.PlayerError]: PlayerErrorEvent;
@@ -55,6 +56,7 @@ export type EventPayloadByEvent = {
   [Event.MetadataCommonReceived]: AudioCommonMetadataReceivedEvent;
   [Event.AndroidConnectorConnected]: AndroidControllerConnectedEvent;
   [Event.AndroidConnectorDisconnected]: AndroidControllerDisconnectedEvent;
+  [Event.TrackMetadataUpdated]: TrackMetadataUpdatedEvent;
 };
 
 type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -24,6 +24,7 @@ import type { RemoteSeekEvent } from './RemoteSeekEvent';
 import type { RemoteSetRatingEvent } from './RemoteSetRatingEvent';
 import type { RemoteSkipEvent } from './RemoteSkipEvent';
 import type { TrackMetadataUpdatedEvent } from './TrackMetadataUpdatedEvent';
+import type { NowPlayingMetadataUpdatedEvent } from './NowPlayingMetadataUpdatedEvent';
 
 export type EventPayloadByEvent = {
   [Event.PlayerError]: PlayerErrorEvent;
@@ -57,6 +58,7 @@ export type EventPayloadByEvent = {
   [Event.AndroidConnectorConnected]: AndroidControllerConnectedEvent;
   [Event.AndroidConnectorDisconnected]: AndroidControllerDisconnectedEvent;
   [Event.TrackMetadataUpdated]: TrackMetadataUpdatedEvent;
+  [Event.NowPlayingMetadataUpdated]: NowPlayingMetadataUpdatedEvent;
 };
 
 type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};

--- a/src/interfaces/events/NowPlayingMetadataUpdatedEvent.ts
+++ b/src/interfaces/events/NowPlayingMetadataUpdatedEvent.ts
@@ -1,0 +1,6 @@
+import type { Track } from '../Track';
+
+export interface NowPlayingMetadataUpdatedEvent {
+  index?: number;
+  track?: Track;
+}

--- a/src/interfaces/events/TrackMetadataUpdatedEvent.ts
+++ b/src/interfaces/events/TrackMetadataUpdatedEvent.ts
@@ -1,0 +1,6 @@
+import type { Track } from '../Track';
+
+export interface TrackMetadataUpdatedEvent {
+  index?: number;
+  track?: Track;
+}


### PR DESCRIPTION
## Summary
- `useActiveTrack` fix (https://github.com/doublesymmetry/react-native-track-player/issues/2158)
  - Fixes long existing bug where `useActiveTrack` doesn't update when `updateMetadataForTrack` is called
- Updated `updateMetadataForTrack`
  - Merges track's current metadata with given metadata patch object, instead of overriding it. 
  - This applies to both - stored track and, if target track is active, then changes are reflected in now playing metadata too
  - If given metadata key value is `undefined` or `null`, current metadata will keep existing respective values
  - If given metadata key value is `empty string`, those values will be set to null in metadata after update
  - Emitting `TRACK_METADATA_UPDATED` event when calling `updateMetadataForTrack`. Same event is now observed from `useActiveTrack`, so that it can update track object after metadata update
- Updated `updateNowPlayingMetadata`
  - It'll use the same merge logic when updating now playing metadata (notification Android & Notification Center iOS)
  - As before, currently active track object remains intact, only now playing info is updated, backwards compatible
  - Emitting `NOW_PLAYING_METADATA_UPDATED` event when calling `updateNowPlayingMetadata `. Same event is now observed from new `useNowPlayingMetadata` hook, which retrieves respective now playing metadata
- Updated `ExampleApp`
  - Replaced random image logic. Previously, images would fail to render sometimes, and they'd render in-app and not in Notification Center and vice-versa. Found this while testing ExampleApp... I have no explanation 🤷 Added hardcoded array of valid image urls to be used when randomising images, which will also be preloaded for faster rendering
  - Added new Action Sheet option, showcasing how to set any of metadata values to empty, after recent changes
  - Added annotations explaining these Action Sheet actions
  - Added new events to `PlaybackService`
- Updated docs

## Breaking changes
Updating metadata by `updateMetadataForTrack` and `updateNowPlayingMetadata` now requires values to be explicitly set to empty strings, in case removal of respective metadata values are desired.
Before, metadata was overriding by given patch object, now it'll be merged/patched.

## Discussion
Regarding `merging` metadata objects when updating - I know this has been a discussion point in the past. Subjectively, I believe patching metadata is the correct way to go, but please let me know reasons behind you decision, whatever it is.
I'll update PR after final decision on patching metadata, if necessary.