### PR TITLE
fix(android): add next prev player commands

### DIFF
--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/models/CustomCommandButton.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/models/CustomCommandButton.kt
@@ -27,23 +27,5 @@ enum class CustomCommandButton(
             .setSessionCommand(SessionCommand("JUMP_FORWARD", Bundle()))
             .setIconResId(R.drawable.media3_icon_skip_forward)
             .build(),
-    ),
-    PREVIOUS(
-        customAction = "PREVIOUS",
-        capability = Capability.SKIP_TO_NEXT,
-        commandButton = CommandButton.Builder()
-            .setDisplayName("Previous")
-            .setSessionCommand(SessionCommand("PREVIOUS", Bundle()))
-            .setIconResId(R.drawable.media3_icon_previous)
-            .build(),
-    ),
-    NEXT(
-        customAction = "NEXT",
-        capability = Capability.SKIP_TO_PREVIOUS,
-        commandButton = CommandButton.Builder()
-            .setDisplayName("Next")
-            .setSessionCommand(SessionCommand("NEXT", Bundle()))
-            .setIconResId(R.drawable.media3_icon_next)
-            .build(),
     );
 }

--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/service/MusicService.kt
@@ -57,8 +57,6 @@ class MusicService : MediaLibraryService() {
                 when (customCommand.customAction) {
                     CustomCommandButton.JUMP_BACKWARD.customAction -> { player.seekBack() }
                     CustomCommandButton.JUMP_FORWARD.customAction -> { player.seekForward() }
-                    CustomCommandButton.NEXT.customAction -> { player.seekToNext() }
-                    CustomCommandButton.PREVIOUS.customAction -> { player.seekToPrevious() }
                 }
                 return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
             }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -834,7 +834,7 @@ class MusicService : HeadlessJsMediaService() {
                 KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
                     // in oxygenOS, the play button in the expanded view always sends KEYCODE_MEDIA_PLAY_PAUSE 
                     // instead of distinguishing between play and pause actions
-                    emit(if (!player.playWhenReady) MusicEvents.BUTTON_PLAY else MusicEvents.BUTTON_PLAY_PAUSE)
+                    emit(if (!player.playWhenReady) MusicEvents.BUTTON_PLAY else MusicEvents.BUTTON_PAUSE)
                     true
                 }
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -832,7 +832,9 @@ class MusicService : HeadlessJsMediaService() {
         if (keyEvent?.action == KeyEvent.ACTION_DOWN) {
             return when (keyEvent.keyCode) {
                 KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
-                    emit(MusicEvents.BUTTON_PLAY_PAUSE)
+                    // in oxygenOS, the play button in the expanded view always sends KEYCODE_MEDIA_PLAY_PAUSE 
+                    // instead of distinguishing between play and pause actions
+                    emit(if (!player.playWhenReady) MusicEvents.BUTTON_PLAY else MusicEvents.BUTTON_PLAY_PAUSE)
                     true
                 }
 

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -166,10 +166,10 @@ class MusicService : HeadlessJsMediaService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         onStartCommandIntentValid = intent != null
         Timber.d("onStartCommand: ${intent?.action}, ${intent?.`package`}")
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        // if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             // HACK: this is not supposed to be here. I definitely screwed up. but Why?
             onMediaKeyEvent(intent)
-        }
+        // }
         // HACK: Why is onPlay triggering onStartCommand??
         if (!commandStarted) {
             commandStarted = true
@@ -290,12 +290,33 @@ class MusicService : HeadlessJsMediaService() {
                     playerCommandsBuilder.add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
                 }
 
+                Capability.SKIP_TO_NEXT -> {
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT)
+                }
+
+                Capability.SKIP_TO_PREVIOUS -> {
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS)
+                }
+
+                Capability.JUMP_FORWARD -> {
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_FORWARD)
+                }
+
+                Capability.JUMP_BACKWARD -> {
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_BACK)
+                }
+
                 else -> {}
             }
         }
+
         customLayout = CustomCommandButton.entries
             .filter { notificationCapabilities.contains(it.capability) }
+            .filter { it != CustomCommandButton.NEXT && it != CustomCommandButton.PREVIOUS }
             .map { c -> c.commandButton }
+
         val sessionCommandsBuilder =
             MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS.buildUpon()
         customLayout.forEach { v ->
@@ -935,8 +956,6 @@ class MusicService : HeadlessJsMediaService() {
                 when (command.customAction) {
                     CustomCommandButton.JUMP_BACKWARD.customAction -> { it.seekBack() }
                     CustomCommandButton.JUMP_FORWARD.customAction -> { it.seekForward() }
-                    CustomCommandButton.NEXT.customAction -> { it.seekToNext() }
-                    CustomCommandButton.PREVIOUS.customAction -> { it.seekToPrevious() }
                 }
             }
             return super.onCustomCommand(session, controller, command, args)

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -314,7 +314,6 @@ class MusicService : HeadlessJsMediaService() {
 
         customLayout = CustomCommandButton.entries
             .filter { notificationCapabilities.contains(it.capability) }
-            .filter { it != CustomCommandButton.NEXT && it != CustomCommandButton.PREVIOUS }
             .map { c -> c.commandButton }
 
         val sessionCommandsBuilder =


### PR DESCRIPTION
**Why / What Problem Does It Solve**

Previously, the command builder didn’t support “skip to next” and “skip to previous” remote/media control commands.

This meant that remote controls (e.g. notification controls, lock screen, media buttons) couldn’t trigger next or previous track actions via the command builder.

The commit adds in those capabilities so that clients using the command builder will have those actions available.

**Implications / Effects**

After this commit, when building PlayerCommandBuilder, users can include “next” and “previous” player commands.

Remote events (or media buttons) that request skip next or skip previous can be wired up using these commands.

Improves usability: users can now navigate tracks via remote controls or UI elements that rely on “next/prev” capabilities.