### PR TITLE
fix(android): update queue with current track

### DIFF
--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -91,8 +91,9 @@ class QueuedAudioPlayer(
         if (queue.isEmpty()) {
             add(item)
         } else {
-            exoPlayer.addMediaItem(currentIndex + 1, item.toMediaItem())
-            exoPlayer.removeMediaItem(currentIndex)
+            val mediaItem = item.toMediaItem()
+            queue[currentIndex] = mediaItem
+            exoPlayer.replaceMediaItem(currentIndex, mediaItem)
             exoPlayer.seekTo(currentIndex, C.TIME_UNSET)
             exoPlayer.prepare()
         }


### PR DESCRIPTION
## Summary

Fixes an issue on Android where getActiveTrack() returns the previous track instead of the currently
playing track when loading a new track via the load() method.

## Root Cause

In QueuedAudioPlayer.kt, the load() method updates ExoPlayer's playlist by adding and removing media
items, but fails to update the internal queue list accordingly. The currentItem property relies on this
queue, leading to a mismatch where the queue contains stale data while ExoPlayer plays the correct
track.

## Solution

Modified the load() method to directly replace the current item in both the queue and ExoPlayer's media
items, ensuring they stay synchronized. This prevents getActiveTrack() from returning outdated track
information.