### PR TITLE
fix(android): guard nullable originalItem before Arguments.fromBundle…

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -545,7 +545,7 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         if (verifyServiceBoundOrReject(callback)) return@launch
 
         if (index >= 0 && index < musicService.tracks.size) {
-            callback.resolve(Arguments.fromBundle(musicService.tracks[index].originalItem))
+            callback.resolve(musicService.tracks[index].originalItem?.let { Arguments.fromBundle(it) })
         } else {
             callback.resolve(null)
         }
@@ -584,9 +584,8 @@ class MusicModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
         if (verifyServiceBoundOrReject(callback)) return@launch
         callback.resolve(
             if (musicService.tracks.isEmpty()) null
-            else Arguments.fromBundle(
-                musicService.tracks[musicService.getCurrentTrackIndex()].originalItem
-            )
+            else musicService.tracks[musicService.getCurrentTrackIndex()]
+                .originalItem?.let { Arguments.fromBundle(it) }
         )
     }
 


### PR DESCRIPTION
fix(android): guard nullable `originalItem` before `Arguments.fromBundle` on v4

On Kotlin 2.1.x (e.g., Expo SDK 54 / RN 0.81), RNTP v4 fails to compile due to
a nullability mismatch: `Arguments.fromBundle` expects a non-null `Bundle`,
but `originalItem` is declared as `Bundle?` in v4.

This change wraps the conversion with a null-safe check so we only call
`Arguments.fromBundle` when `originalItem` is non-null. Behavior is unchanged
for JS: when the backing bundle is null, methods still resolve to `null`.

Before (examples):
- MusicModule.getTrack: `Arguments.fromBundle(musicService.tracks[index].originalItem)`
- MusicModule.getActiveTrack: `Arguments.fromBundle(...originalItem)`

After:
- `...originalItem?.let { Arguments.fromBundle(it) }`

Why
- Fixes v4 compilation on Kotlin 2.1.x without altering runtime behavior.

Testing
- “Test plan”: built lib + example runs on Android emulator; no crashes; compile success.
- Built Android with Kotlin 2.1.20 / AGP 8.7.x / Gradle 8.14.x.
- `:react-native-track-player:compileDebugKotlin` succeeds.
- App boots on Android emulator (Pixel_9_Pro).
- Sanity-checked `getTrack` / `getActiveTrack` return `null` when no bundle.


Notes
- This PR targets the `v4` branch (maintenance). `main` already migrated to
  the new module/codegen and doesn’t exhibit this specific issue.

Closes: #2530 