### PR TITLE
fix(android): check added to trigger onMediaKeyEvent if OxygenOS < 15

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -166,10 +166,16 @@ class MusicService : HeadlessJsMediaService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         onStartCommandIntentValid = intent != null
         Timber.d("onStartCommand: ${intent?.action}, ${intent?.`package`}")
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            // HACK: this is not supposed to be here. I definitely screwed up. but Why?
-            onMediaKeyEvent(intent)
+
+        val manufacturer = Build.MANUFACTURER
+        val brand = Build.BRAND
+        val isOnePlus = manufacturer.equals("OnePlus", ignoreCase = true) && brand.equals("OnePlus", ignoreCase = true);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || isOnePlus && Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+          // Hack - fixes onMediaKeyEvent on Android < 13 & OxygenOS 14
+          onMediaKeyEvent(intent)
         }
+
         // HACK: Why is onPlay triggering onStartCommand??
         if (!commandStarted) {
             commandStarted = true


### PR DESCRIPTION
## Summary
Fixes an issue on Oxygen OS < 15 where `onMediaButton` doesn't get called due to the OEM's implementation. As a result, the lock screen controls didn't work on Oxygen 14.

## Root Cause
This was also an issue in Android 13 and below. It looks like OnePlus forgot to patch it on their end in Oxygen 14, but managed to fix it in Oxygen 15. I couldn't test it directly on 15, but according to [this](https://github.com/doublesymmetry/react-native-track-player/issues/2507#issuecomment-3586296223) it seems to be working fine on Oxygen 15. 

## Solution
I've extended the original hack for Android 13 so it applies to Oxygen14 as well. Tested on a OnePlus9 (Oxygen 14) and a Pixel 9, to make sure it didn't break anything on non-One Plus devices. Both worked just fine. 