### PR TITLE
feat(android): add repeat button to control center

### DIFF
--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/models/Capability.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/models/Capability.kt
@@ -15,5 +15,6 @@ enum class Capability {
     SET_RATING,
     LIKE,
     DISLIKE,
-    BOOKMARK
+    BOOKMARK,
+    REPEAT
 }

--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/models/CustomCommandButton.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/models/CustomCommandButton.kt
@@ -45,5 +45,14 @@ enum class CustomCommandButton(
             .setSessionCommand(SessionCommand("NEXT", Bundle()))
             .setIconResId(R.drawable.media3_icon_next)
             .build(),
+    ),
+    REPEAT(
+        customAction = "REPEAT",
+        capability = Capability.REPEAT,
+        commandButton = CommandButton.Builder()
+            .setDisplayName("Repeat")
+            .setSessionCommand(SessionCommand("REPEAT", Bundle()))
+            .setIconResId(androidx.media3.ui.R.drawable.exo_icon_repeat_off)
+            .build(),
     );
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicEvents.kt
@@ -35,6 +35,7 @@ class MusicEvents(private val reactContext: ReactContext) : BroadcastReceiver() 
         const val BUTTON_JUMP_BACKWARD = "remote-jump-backward"
         const val BUTTON_DUCK = "remote-duck"
         const val BUTTON_BROWSE = "remote-browse"
+        const val BUTTON_REPEAT = "remote-repeat"
 
         // Playback Events
         const val PLAYBACK_PLAY_WHEN_READY_CHANGED = "playback-play-when-ready-changed"

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -157,6 +157,7 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
             this["CAPABILITY_SET_RATING"] = Capability.SET_RATING.ordinal
             this["CAPABILITY_JUMP_FORWARD"] = Capability.JUMP_FORWARD.ordinal
             this["CAPABILITY_JUMP_BACKWARD"] = Capability.JUMP_BACKWARD.ordinal
+            this["CAPABILITY_REPEAT"] = 99
 
             // States
             this["STATE_NONE"] = State.None.state

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -157,7 +157,7 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
             this["CAPABILITY_SET_RATING"] = Capability.SET_RATING.ordinal
             this["CAPABILITY_JUMP_FORWARD"] = Capability.JUMP_FORWARD.ordinal
             this["CAPABILITY_JUMP_BACKWARD"] = Capability.JUMP_BACKWARD.ordinal
-            this["CAPABILITY_REPEAT"] = 99
+            this["CAPABILITY_REPEAT"] = Capability.REPEAT.ordinal
 
             // States
             this["STATE_NONE"] = State.None.state

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -272,7 +272,7 @@ class MusicService : HeadlessJsMediaService() {
             notificationCapabilities.addAll(capabilities)
         }
 
-        val hasRepeatCapability = rawNotificationCapabilities.contains(CAPABILITY_REPEAT)
+        val hasRepeatCapability = rawNotificationCapabilities.contains(Capability.REPEAT.ordinal)
 
         val playerCommandsBuilder = Player.Commands.Builder().addAll(
             // HACK: without COMMAND_GET_CURRENT_MEDIA_ITEM, notification cannot be created
@@ -321,7 +321,7 @@ class MusicService : HeadlessJsMediaService() {
             val repeatBtn = CommandButton.Builder()
                 .setDisplayName("Repeat")
                 .setIconResId(repeatIcon)
-                .setSessionCommand(SessionCommand(ACTION_REPEAT, Bundle.EMPTY))
+                .setSessionCommand(SessionCommand(CustomCommandButton.REPEAT.customAction, Bundle.EMPTY))
                 .build()
             (customLayout as MutableList).add(repeatBtn)
         }
@@ -967,7 +967,7 @@ class MusicService : HeadlessJsMediaService() {
                     CustomCommandButton.JUMP_FORWARD.customAction -> { it.seekForward() }
                     CustomCommandButton.NEXT.customAction -> { it.seekToNext() }
                     CustomCommandButton.PREVIOUS.customAction -> { it.seekToPrevious() }
-                    ACTION_REPEAT -> {
+                    CustomCommandButton.REPEAT.customAction -> {
                          emit(MusicEvents.BUTTON_REPEAT)
                     }
                 }
@@ -1063,7 +1063,6 @@ class MusicService : HeadlessJsMediaService() {
         const val DEFAULT_JUMP_INTERVAL = 15.0
         const val DEFAULT_STOP_FOREGROUND_GRACE_PERIOD = 5
         
-        const val CAPABILITY_REPEAT = 99
-        const val ACTION_REPEAT = "action_repeat"
+
     }
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -209,6 +209,11 @@ class MusicService : HeadlessJsMediaService() {
             wakeMode = playerOptions?.getInt(WAKE_MODE, 0) ?: 0
         )
         player = QueuedAudioPlayer(this@MusicService, options)
+        player.forwardingPlayer.addListener(object : Player.Listener {
+            override fun onRepeatModeChanged(repeatMode: Int) {
+                latestOptions?.let { updateOptions(it) }
+            }
+        })
         fakePlayer.release()
         mediaSession.player = player.forwardingPlayer
         observeEvents()
@@ -254,12 +259,20 @@ class MusicService : HeadlessJsMediaService() {
                 }
             }
         }
-        val capabilities =
-            options.getIntegerArrayList("capabilities")?.map { Capability.entries[it] }
-                ?: emptyList()
-        var notificationCapabilities = options.getIntegerArrayList("notificationCapabilities")
-            ?.map { Capability.entries[it] } ?: emptyList()
-        if (notificationCapabilities.isEmpty()) notificationCapabilities = capabilities
+        val rawNotificationCapabilities = options.getIntegerArrayList("notificationCapabilities") ?: emptyList()
+        val entries = Capability.entries
+        val notificationCapabilities = rawNotificationCapabilities.mapNotNull {
+            if (it >= 0 && it < entries.size) entries[it] else null
+        } .toMutableList()
+        
+        if (notificationCapabilities.isEmpty()) {
+            val capabilities = options.getIntegerArrayList("capabilities")?.mapNotNull {
+                 if (it >= 0 && it < entries.size) entries[it] else null
+            } ?: emptyList()
+            notificationCapabilities.addAll(capabilities)
+        }
+
+        val hasRepeatCapability = rawNotificationCapabilities.contains(CAPABILITY_REPEAT)
 
         val playerCommandsBuilder = Player.Commands.Builder().addAll(
             // HACK: without COMMAND_GET_CURRENT_MEDIA_ITEM, notification cannot be created
@@ -296,6 +309,23 @@ class MusicService : HeadlessJsMediaService() {
         customLayout = CustomCommandButton.entries
             .filter { notificationCapabilities.contains(it.capability) }
             .map { c -> c.commandButton }
+            .toMutableList()
+
+        if (hasRepeatCapability) {
+            val repeatIcon = when(player.repeatMode) {
+                RepeatMode.OFF -> androidx.media3.ui.R.drawable.exo_icon_repeat_off
+                RepeatMode.ONE -> androidx.media3.ui.R.drawable.exo_icon_repeat_one
+                RepeatMode.ALL -> androidx.media3.ui.R.drawable.exo_icon_repeat_all
+                else -> androidx.media3.ui.R.drawable.exo_icon_repeat_off
+            }
+            val repeatBtn = CommandButton.Builder()
+                .setDisplayName("Repeat")
+                .setIconResId(repeatIcon)
+                .setSessionCommand(SessionCommand(ACTION_REPEAT, Bundle.EMPTY))
+                .build()
+            (customLayout as MutableList).add(repeatBtn)
+        }
+
         val sessionCommandsBuilder =
             MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS.buildUpon()
         customLayout.forEach { v ->
@@ -937,6 +967,9 @@ class MusicService : HeadlessJsMediaService() {
                     CustomCommandButton.JUMP_FORWARD.customAction -> { it.seekForward() }
                     CustomCommandButton.NEXT.customAction -> { it.seekToNext() }
                     CustomCommandButton.PREVIOUS.customAction -> { it.seekToPrevious() }
+                    ACTION_REPEAT -> {
+                         emit(MusicEvents.BUTTON_REPEAT)
+                    }
                 }
             }
             return super.onCustomCommand(session, controller, command, args)
@@ -1029,5 +1062,8 @@ class MusicService : HeadlessJsMediaService() {
 
         const val DEFAULT_JUMP_INTERVAL = 15.0
         const val DEFAULT_STOP_FOREGROUND_GRACE_PERIOD = 5
+        
+        const val CAPABILITY_REPEAT = 99
+        const val ACTION_REPEAT = "action_repeat"
     }
 }

--- a/src/NativeTrackPlayer.ts
+++ b/src/NativeTrackPlayer.ts
@@ -67,6 +67,7 @@ export interface Spec extends TurboModule {
     CAPABILITY_SET_RATING: number;
     CAPABILITY_JUMP_FORWARD: number;
     CAPABILITY_JUMP_BACKWARD: number;
+    CAPABILITY_REPEAT: number;
 
     // States
     STATE_NONE: string;

--- a/src/constants/Capability.ts
+++ b/src/constants/Capability.ts
@@ -13,5 +13,5 @@ export enum Capability {
   JumpForward = Constants?.CAPABILITY_JUMP_FORWARD ?? 10,
   JumpBackward = Constants?.CAPABILITY_JUMP_BACKWARD ?? 11,
   SetRating = Constants?.CAPABILITY_SET_RATING ?? 12,
-  Repeat = Constants?.CAPABILITY_REPEAT ?? 99,
+  Repeat = Constants?.CAPABILITY_REPEAT ?? 15,
 }

--- a/src/constants/Capability.ts
+++ b/src/constants/Capability.ts
@@ -13,4 +13,5 @@ export enum Capability {
   JumpForward = Constants?.CAPABILITY_JUMP_FORWARD ?? 10,
   JumpBackward = Constants?.CAPABILITY_JUMP_BACKWARD ?? 11,
   SetRating = Constants?.CAPABILITY_SET_RATING ?? 12,
+  Repeat = Constants?.CAPABILITY_REPEAT ?? 99,
 }

--- a/src/constants/Event.ts
+++ b/src/constants/Event.ts
@@ -97,6 +97,10 @@ export enum Event {
    * See https://rntp.dev/docs/api/events#remotebookmark-ios-only
    **/
   RemoteBookmark = 'remote-bookmark',
+  /** (Android only) Fired when the user presses the repeat button in the now
+   * playing center.
+   **/
+  RemoteRepeat = 'remote-repeat',
   /**
    * (Android only) Fired when the user selects a track from an external device.
    * See https://rntp.dev/docs/api/events#remoteplayid

--- a/src/interfaces/events/EventPayloadByEvent.ts
+++ b/src/interfaces/events/EventPayloadByEvent.ts
@@ -49,6 +49,7 @@ export type EventPayloadByEvent = {
   [Event.RemoteLike]: never;
   [Event.RemoteDislike]: never;
   [Event.RemoteBookmark]: never;
+  [Event.RemoteRepeat]: never;
   [Event.PlaybackResume]: PlaybackResumeEvent;
   [Event.MetadataChapterReceived]: AudioMetadataReceivedEvent;
   [Event.MetadataTimedReceived]: AudioMetadataReceivedEvent;

--- a/web/TrackPlayerModule.ts
+++ b/web/TrackPlayerModule.ts
@@ -26,6 +26,7 @@ export class TrackPlayerModule extends PlaylistPlayer implements Spec {
       CAPABILITY_SKIP_TO_NEXT: 9,
       CAPABILITY_SKIP_TO_PREVIOUS: 10,
       CAPABILITY_STOP: 11,
+      CAPABILITY_REPEAT: 99,
 
       // Rating Types
       RATING_HEART: 0,


### PR DESCRIPTION
## Summary
This PR implements proper support for the `Capability.Repeat` feature on Android. It allows the repeat button to appear in the Android notification and customizes the event handling to ensure the Repeat Mode state remains synchronized between the Notification and the App UI.

## Changes
-   **Android Native**
    -   Handled `ACTION_REPEAT` to emit a `RemoteRepeat` event.
    -   Added a `Player.Listener` to observe events and immediately update the notification options, ensuring the icon reflects the new state.
-   **TypeScript Definitions:**
    -   Added `Capability.Repeat`.
    -   Added `Event.RemoteRepeat` 
    -   Updated EventPayloadByEvent interface to support the new event type.
-   **Documentation:**
    -   Updated comments to reflect Android support for `RemoteRepeat`.

## Notes
-   This implementation focuses on Android support. iOS implementation is unchanged because i don't have a mac to test it in ios.
