### PR TITLE
feat(ios): add iosNextPreviousCommandsSkip option for AirPods seek support

### DIFF
--- a/ios/TrackPlayer.swift
+++ b/ios/TrackPlayer.swift
@@ -23,6 +23,7 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
     private var shouldResumePlaybackAfterInterruptionEnds: Bool = false
     private var forwardJumpInterval: NSNumber? = nil;
     private var backwardJumpInterval: NSNumber? = nil;
+    private var nextPreviousCommandTargets: [Any] = []
     private var sessionCategory: AVAudioSession.Category = .playback
     private var sessionCategoryMode: AVAudioSession.Mode = .default
     private var sessionCategoryPolicy: AVAudioSession.RouteSharingPolicy = .default
@@ -283,11 +284,56 @@ public class NativeTrackPlayerImpl: NSObject, AudioSessionControllerDelegate {
                 )
             }
 
+        // Configure next/previous track commands to act as skip forward/backward.
+        // This enables AirPods double/triple-press to seek without affecting the
+        // lock screen UI (which continues to show skip-interval buttons).
+        configureNextPreviousAsSkip(
+            enabled: options["iosNextPreviousCommandsSkip"] as? Bool ?? false
+        )
+
         configureProgressUpdateEvent(
             interval: ((options["progressUpdateEventInterval"] as? NSNumber) ?? 0).doubleValue
         )
 
         resolve(NSNull())
+    }
+
+    /// Registers `nextTrackCommand` / `previousTrackCommand` on the shared
+    /// `MPRemoteCommandCenter` with handlers that seek by the configured jump
+    /// intervals. This enables AirPods double-press (skip forward) and
+    /// triple-press (skip backward) without adding `SkipToNext` /
+    /// `SkipToPrevious` to the capabilities array, so the lock screen / Control
+    /// Center continues to show skip-interval buttons instead of next/previous
+    /// track arrows.
+    private func configureNextPreviousAsSkip(enabled: Bool) {
+        let commandCenter = MPRemoteCommandCenter.shared()
+
+        // Always clean up previously registered targets first
+        for target in nextPreviousCommandTargets {
+            commandCenter.nextTrackCommand.removeTarget(target)
+            commandCenter.previousTrackCommand.removeTarget(target)
+        }
+        nextPreviousCommandTargets.removeAll()
+
+        guard enabled else { return }
+
+        commandCenter.nextTrackCommand.isEnabled = true
+        let nextTarget = commandCenter.nextTrackCommand.addTarget { [weak self] _ in
+            guard let self = self else { return .commandFailed }
+            let interval = self.forwardJumpInterval?.doubleValue ?? 30.0
+            self.player.seek(to: self.player.currentTime + interval)
+            return .success
+        }
+        nextPreviousCommandTargets.append(nextTarget)
+
+        commandCenter.previousTrackCommand.isEnabled = true
+        let prevTarget = commandCenter.previousTrackCommand.addTarget { [weak self] _ in
+            guard let self = self else { return .commandFailed }
+            let interval = self.backwardJumpInterval?.doubleValue ?? 15.0
+            self.player.seek(to: max(self.player.currentTime - interval, 0))
+            return .success
+        }
+        nextPreviousCommandTargets.append(prevTarget)
     }
 
     private func configureProgressUpdateEvent(interval: Double) {

--- a/src/interfaces/UpdateOptions.ts
+++ b/src/interfaces/UpdateOptions.ts
@@ -14,6 +14,21 @@ export interface UpdateOptions {
   dislikeOptions?: FeedbackOptions;
   bookmarkOptions?: FeedbackOptions;
 
+  /**
+   * iOS only. When `true`, registers `nextTrackCommand` and
+   * `previousTrackCommand` on `MPRemoteCommandCenter` but routes them to skip
+   * forward / backward by the configured jump intervals instead of emitting
+   * `Event.RemoteNext` / `Event.RemotePrevious`.
+   *
+   * This enables AirPods double-press (skip forward) and triple-press (skip
+   * backward) without changing the lock screen / Control Center UI, which will
+   * continue to show the skip-interval buttons when `Capability.JumpForward`
+   * and `Capability.JumpBackward` are in the `capabilities` array.
+   *
+   * Default: `false`
+   */
+  iosNextPreviousCommandsSkip?: boolean;
+
   capabilities?: Capability[];
 
   // android


### PR DESCRIPTION
## Summary

Adds a new `iosNextPreviousCommandsSkip` option to `updateOptions()` that enables AirPods double-press (seek forward) and triple-press (seek backward) for podcast and audiobook apps, without changing the lock screen / Control Center button layout.

## Problem

Podcast and audiobook apps typically configure their lock screen controls with `Capability.JumpForward` and `Capability.JumpBackward` to show skip-interval buttons (e.g., "15s back", "30s forward") instead of next/previous track arrows. However, this means AirPods double-press and triple-press do nothing because:

1. **`Capability.Skip` is a NOOP on iOS** — it maps to `"NOOP"` in the constants dictionary and registers no commands
2. **`Capability.SkipToNext` / `Capability.SkipToPrevious`** register `nextTrackCommand` / `previousTrackCommand`, which _changes the lock screen UI_ to show next/previous track arrows, replacing the skip-interval buttons

There is currently no way to:
- Keep the skip-interval buttons on the lock screen (via `JumpForward` / `JumpBackward`)
- AND have AirPods double/triple-press trigger seek operations

This is a common requirement for podcast apps — Apple's own Podcasts app supports this exact behavior.

## Solution

A new `iosNextPreviousCommandsSkip` boolean option in `updateOptions()` that, when `true`:

1. Directly registers `nextTrackCommand` and `previousTrackCommand` handlers on `MPRemoteCommandCenter.shared()` **outside** of the RNTP capabilities system
2. Routes these handlers to `player.seek()` using the configured `forwardJumpInterval` / `backwardJumpInterval`
3. Does **not** add these commands to `player.remoteCommands`, so they don't affect the lock screen button layout

### Why register outside the capabilities system?

The RNTP capabilities array maps 1:1 to `player.remoteCommands`, which SwiftAudioEx uses to determine both the command handlers AND the lock screen UI. By registering directly on `MPRemoteCommandCenter.shared()`, we decouple the AirPods command handling from the lock screen layout.

### How AirPods commands work on iOS

AirPods button presses map to `MPRemoteCommandCenter` commands:
- **Single press** → `togglePlayPauseCommand`
- **Double press** → `nextTrackCommand`
- **Triple press** → `previousTrackCommand`

These are hardware-level mappings that cannot be changed. The only way to make double-press seek forward is to register a `nextTrackCommand` handler that performs a seek.

## Usage

```typescript
await TrackPlayer.updateOptions({
  capabilities: [
    Capability.Play,
    Capability.Pause,
    Capability.JumpForward,
    Capability.JumpBackward,
    Capability.SeekTo,
  ],
  forwardJumpInterval: 30,
  backwardJumpInterval: 15,
  // Enable AirPods double/triple-press to seek forward/backward
  iosNextPreviousCommandsSkip: true,
});
```

**Lock screen result:** Shows skip-interval buttons (⟲15  advancement advancement advancement ▶ ⟳30) — same as without the option.

**AirPods result:**
- Double-press → seeks forward by `forwardJumpInterval` (30s)
- Triple-press → seeks backward by `backwardJumpInterval` (15s)

## Changes

### `src/interfaces/UpdateOptions.ts`
- Added `iosNextPreviousCommandsSkip?: boolean` with JSDoc documentation

### `ios/TrackPlayer.swift`
- Added `nextPreviousCommandTargets` instance property to track registered command targets for cleanup
- Added `configureNextPreviousAsSkip(enabled:)` private method that:
  - Cleans up any previously registered targets (safe to call multiple times)
  - When enabled: registers `nextTrackCommand` and `previousTrackCommand` on `MPRemoteCommandCenter.shared()` with seek handlers
  - When disabled: removes targets and returns (commands stay managed by RNTP's capabilities system)
- Called from `update(options:resolve:reject:)` after `player.remoteCommands` is set

### Backward compatibility

- Default value is `false` — no behavior change for existing users
- The option is iOS-only and ignored on Android
- Does not interfere with `Capability.SkipToNext` / `Capability.SkipToPrevious` if they are also in the capabilities array
- Properly cleans up on subsequent `updateOptions()` calls

## Test plan

- [ ] Set `iosNextPreviousCommandsSkip: true` with `JumpForward`/`JumpBackward` in capabilities
  - [ ] Verify lock screen shows skip-interval buttons (not next/prev track arrows)
  - [ ] Verify AirPods double-press seeks forward by `forwardJumpInterval`
  - [ ] Verify AirPods triple-press seeks backward by `backwardJumpInterval`
- [ ] Set `iosNextPreviousCommandsSkip: false` (or omit)
  - [ ] Verify AirPods double-press has no effect (current default behavior)
  - [ ] Verify lock screen is unaffected
- [ ] Call `updateOptions()` multiple times toggling `iosNextPreviousCommandsSkip`
  - [ ] Verify no duplicate handlers or memory leaks
- [ ] Use with `SkipToNext`/`SkipToPrevious` in capabilities simultaneously
  - [ ] Verify no crashes or conflicts
- [ ] Test with different `forwardJumpInterval`/`backwardJumpInterval` values
- [ ] Test with AirPods Pro (stem press) and AirPods (tap gesture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)