### PR TITLE
fix(android): sync Kotlin queue in QueuedAudioPlayer.load()

### DIFF
--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/players/QueuedAudioPlayer.kt
@@ -91,7 +91,13 @@ class QueuedAudioPlayer(
         if (queue.isEmpty()) {
             add(item)
         } else {
-            exoPlayer.addMediaItem(currentIndex + 1, item.toMediaItem())
+            val mediaItem = item.toMediaItem()
+            // Keep the Kotlin queue in sync with ExoPlayer's internal queue.
+            // Without this, queue[0] always returns the first-ever loaded station,
+            // causing updateMetadataForTrack to replace the current stream URL with
+            // the original station's URL every time metadata is refreshed.
+            queue[currentIndex] = mediaItem
+            exoPlayer.addMediaItem(currentIndex + 1, mediaItem)
             exoPlayer.removeMediaItem(currentIndex)
             exoPlayer.seekTo(currentIndex, C.TIME_UNSET)
             exoPlayer.prepare()


### PR DESCRIPTION
## Summary

In the `else` branch of `QueuedAudioPlayer.load()`, ExoPlayer's internal playlist was updated (via `addMediaItem` + `removeMediaItem`) but the Kotlin `queue` LinkedList was never updated to match. This caused `queue[currentIndex]` to always return the first-ever loaded item after switching tracks.

The immediate symptom: `updateMetadataForTrack(index, bundle)` reads the current track from `queue[index]`, then calls `replaceItem(index, track.toAudioItem())`. Because `queue[0]` still pointed to the original track, `replaceItem` would call `exoPlayer.replaceMediaItem` with the original stream URL — reverting playback to the first-ever loaded track within ~10 seconds of switching (the metadata refresh interval).

## Root cause

`load()` in the non-empty queue case bypasses `add()` and manipulates ExoPlayer directly, but forgot to mirror the change to the Kotlin `queue`:

```kotlin
// Before — queue[currentIndex] is never updated
} else {
    exoPlayer.addMediaItem(currentIndex + 1, item.toMediaItem())
    exoPlayer.removeMediaItem(currentIndex)
    exoPlayer.seekTo(currentIndex, C.TIME_UNSET)
    exoPlayer.prepare()
}
```

All properties that read from the queue (`currentItem`, `items`, `previousItems`, `nextItems`) and any caller that uses `queue[index]` directly (e.g. `replaceItem`) receive stale data after `load()`.

## Fix

Materialise the `MediaItem` once and assign it to `queue[currentIndex]` before passing it to ExoPlayer:

```kotlin
} else {
    val mediaItem = item.toMediaItem()
    // Keep the Kotlin queue in sync with ExoPlayer's internal queue.
    // Without this, queue[currentIndex] always returns the first-ever loaded item,
    // causing updateMetadataForTrack to call replaceItem() with a stale stream URL
    // every time metadata is refreshed.
    queue[currentIndex] = mediaItem
    exoPlayer.addMediaItem(currentIndex + 1, mediaItem)
    exoPlayer.removeMediaItem(currentIndex)
    exoPlayer.seekTo(currentIndex, C.TIME_UNSET)
    exoPlayer.prepare()
}
```