### PR TITLE
Start MusicService in foreground for API 26+

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -217,6 +217,11 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
         val musicModule = this
         try {
             Intent(context, MusicService::class.java).also { intent ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
                 context.bindService(intent, musicModule, Context.BIND_AUTO_CREATE)
                 val sessionToken =
                     SessionToken(context, ComponentName(context, MusicService::class.java))

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -170,11 +170,8 @@ class MusicService : HeadlessJsMediaService() {
             // HACK: this is not supposed to be here. I definitely screwed up. but Why?
             onMediaKeyEvent(intent)
         }
-        // HACK: Why is onPlay triggering onStartCommand??
-        if (!commandStarted) {
-            commandStarted = true
-            super.onStartCommand(intent, flags, startId)
-        }
+        // Always call super.onStartCommand() to keep foreground service status
++       super.onStartCommand(intent, flags, startId)
         return START_STICKY
     }
 
@@ -206,7 +203,7 @@ class MusicService : HeadlessJsMediaService() {
             handleAudioFocus = playerOptions?.getBoolean(AUTO_HANDLE_INTERRUPTIONS) ?: true,
             interceptPlayerActionsTriggeredExternally = true,
             skipSilence = playerOptions?.getBoolean(SKIP_SILENCE) ?: false,
-            wakeMode = playerOptions?.getInt(WAKE_MODE, 0) ?: 0
+            wakeMode = BundleUtils.getInt(playerOptions, WAKE_MODE, 0)
         )
         player = QueuedAudioPlayer(this@MusicService, options)
         fakePlayer.release()


### PR DESCRIPTION
When the screen is turned off, Android kills the MusicService after ~2 minutes because it lacks an explicit "Started" state, even if audio is playing.

This PR adds an explicit call to startForegroundService (or startService for older APIs) prior to binding.

Tested successfully on a Pixel 9a with Android 16