### PR TITLE
fix: resolve Bundle nullable type mismatch for Kotlin 2.x compatibility

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -541,7 +541,7 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
 
     override fun getPlaybackState(callback: Promise) = launchInScope {
         if (verifyServiceBoundOrReject(callback)) return@launchInScope
-        callback.resolve(Arguments.fromBundle(musicService.getPlayerStateBundle(musicService.state)))
+        callback.resolve(Arguments.fromBundle(musicService.getPlayerStateBundle(musicService.state) ?: Bundle()))
     }
 
     override fun acquireWakeLock(callback: Promise) = launchInScope {


### PR DESCRIPTION
## Problem
Building with Kotlin 2.1.20 (used in Expo SDK 53+) fails with:

  Argument type mismatch: actual type is 'Bundle?', but 'Bundle' was expected
  - MusicModule.kt:548
  - MusicModule.kt:588

Kotlin 2.x enforces stricter null-safety. `Arguments.toBundle()` and 
`getPlayerStateBundle()` return nullable `Bundle?`, but the call sites 
expected non-null `Bundle`.

## Fix
Added `?: Bundle()` fallback at both call sites to satisfy the Kotlin 
2.x type checker without changing runtime behavior.

## Tested on
- react-native-track-player 4.1.2
- Kotlin 2.1.20
- Expo SDK 53 / EAS Build