### PR TITLE
fix(android): prevent headless restart when stop-playback-and-remove-notification is set (#2617)

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -175,7 +175,11 @@ class MusicService : HeadlessJsMediaService() {
             commandStarted = true
             super.onStartCommand(intent, flags, startId)
         }
-        return START_STICKY
+        return if (appKilledPlaybackBehavior == AppKilledPlaybackBehavior.STOP_PLAYBACK_AND_REMOVE_NOTIFICATION) {
+            START_NOT_STICKY // use START_NOT_STICKY to prevent service restart after exitProcess(0)
+        } else {
+            START_STICKY // allow background playback to persist for CONTINUE_PLAYBACK and PAUSE_PLAYBACK
+        }
     }
 
     @MainThread


### PR DESCRIPTION
return START_NOT_STICKY when AppKilledPlaybackBehavior is StopPlaybackAndRemoveNotification to prevent Android from restarting the service after exitProcess(0). return START_STICKY for ContinuePlayback and PausePlayback to allow background playback to persist.