### PR TITLE
fix(android): guard against null ReactHost and emit crashes on new architecture (#2619)

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/HeadlessJsMediaService.java
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/HeadlessJsMediaService.java
@@ -183,7 +183,7 @@
     protected ReactContext getReactContext() {
         if (DefaultNewArchitectureEntryPoint.getBridgelessEnabled()) {
             ReactHost reactHost = getReactHost();
-            Assertions.assertNotNull(reactHost, "React host is null in newArchitecture");
+            if (reactHost == null) { return null; }
             return reactHost.getCurrentReactContext();
         }
 
@@ -197,6 +197,7 @@
 
         if (DefaultNewArchitectureEntryPoint.getBridgelessEnabled()) { // new arch
             final ReactHost reactHost = getReactHost();
+            if (reactHost == null) { return; }
             reactHost.addReactInstanceEventListener(
                     new ReactInstanceEventListener() {
                         @Override

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -674,16 +674,24 @@ class MusicService : HeadlessJsMediaService() {
     @SuppressLint("VisibleForTests")
     @MainThread
     fun emit(event: String, data: Bundle? = null) {
-        reactContext?.emitDeviceEvent(event, data?.let { Arguments.fromBundle(it) })
+        try {
+            reactContext?.emitDeviceEvent(event, data?.let { Arguments.fromBundle(it) })
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to emit event: $event")
+        }
     }
 
     @SuppressLint("VisibleForTests")
     @MainThread
     private fun emitList(event: String, data: List<Bundle> = emptyList()) {
-        val payload = Arguments.createArray()
-        data.forEach { payload.pushMap(Arguments.fromBundle(it)) }
+        try {
+            val payload = Arguments.createArray()
+            data.forEach { payload.pushMap(Arguments.fromBundle(it)) }
 
-        reactContext?.emitDeviceEvent(event, payload)
+            reactContext?.emitDeviceEvent(event, payload)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to emitList event: $event")
+        }
     }
 
     override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig {


### PR DESCRIPTION
add null checks for ReactHost in HeadlessJsMediaService.getReactContext() and createReactContextAndScheduleTask() to prevent NPEs on new architecture (bridgeless mode). wrap emit() and emitList() in MusicService with try/catch to prevent uncaught exceptions from crashing the service when the React context is transiently unavailable while backgrounded.