### PR TITLE
fix(android): release fakePlayer and mediaSession in onDestroy when player is uninitialized (#2621)

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -796,6 +796,11 @@ class MusicService : HeadlessJsMediaService() {
             Timber.d("Releasing media session and destroying player")
             mediaSession.release()
             player.destroy()
+        } else {
+            // release fakePlayer and mediaSession even when player was not initialized
+            // to prevent resource leaks on service restart
+            fakePlayer.release()
+            mediaSession.release()
         }
 
         progressUpdateJob?.cancel()


### PR DESCRIPTION
fakePlayer (ExoPlayer) and mediaSession are always created in onCreate but were only released in onDestroy when player was initialized. if the service is destroyed before setupPlayer() is called, these native resources were silently leaked. with START_STICKY causing service restarts, each cycle creates a new fakePlayer without releasing the previous one, leading to accumulated native resource consumption and OOM crashes. add an else branch to onDestroy to release both resources when player has not been initialized.