### PR TITLE
fix(android): add SKIP_TO_NEXT/PREVIOUS to available player commands

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -290,6 +290,16 @@ class MusicService : HeadlessJsMediaService() {
                     playerCommandsBuilder.add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
                 }
 
+                Capability.SKIP_TO_NEXT -> {
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT)
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                }
+
+                Capability.SKIP_TO_PREVIOUS -> {
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS)
+                    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                }
+
                 else -> {}
             }
         }


### PR DESCRIPTION
## Problem

When `Capability.SkipToNext` / `Capability.SkipToPrevious` are passed to `updateOptions`, the corresponding Media3 `Player.Commands` (`COMMAND_SEEK_TO_NEXT(_MEDIA_ITEM)` / `COMMAND_SEEK_TO_PREVIOUS(_MEDIA_ITEM)`) are never added to the player's `availableCommands`. As a result, the next/previous buttons on the lock screen, notification, and Android Auto remain disabled even when the app declares those capabilities.

Other capabilities (`PLAY/PAUSE`, `STOP`, `SEEK_TO`) are already wired up in the same `when` branch, so this looks like an oversight.

## Fix

Add two cases next to the existing `Capability.SEEK_TO` branch in `MusicService.updateOptions` — minimal change, same pattern:

```kotlin
Capability.SKIP_TO_NEXT -> {
    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT)
    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
}
Capability.SKIP_TO_PREVIOUS -> {
    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS)
    playerCommandsBuilder.add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
}
```

## Why this is safe

`BaseAudioPlayer` already intercepts `seekToNext()` / `seekToNextMediaItem()` (and the previous variants) via a `ForwardingPlayer` override (`BaseAudioPlayer.kt:485-499`). These overrides do not advance the native queue — they only emit `MediaSessionCallback.NEXT` / `PREVIOUS`, which `MusicService` translates into the `BUTTON_SKIP_NEXT` / `BUTTON_SKIP_PREVIOUS` events (`remote-next` / `remote-previous`) consumed by JS.

In other words, the JS-side `Event.RemoteNext` / `Event.RemotePrevious` pipeline is already wired up; only the `availableCommands` registration needed to make the lock screen / notification buttons actually pressable was missing. This PR adds that, without changing native queue-advance behavior or the JS contract.

## Relation to #2517

A previous PR (#2517) addressed the same root cause but bundled additional changes (removal of `CustomCommandButton`, modifications to `KEYCODE_MEDIA_PLAY_PAUSE` handling) and was closed as stale without merge. This PR intentionally limits the scope to only the `availableCommands` registration, leaving `CustomCommandButton`, `onMediaKeyEvent`, and `JUMP_FORWARD/BACKWARD` untouched.

## Repro

1. Configure TrackPlayer with `capabilities: [Capability.Play, Capability.Pause, Capability.SkipToNext, Capability.SkipToPrevious]` and a queue of 2+ tracks.
2. Start playback, lock the device (or pull down the notification shade).
3. Tap the next/previous buttons on the lock screen / notification.

**Before**: buttons are visible but disabled / no-op.
**After**: buttons advance/rewind the queue as expected.

## Platform impact

- Android only. iOS already handles `SkipToNext` / `SkipToPrevious` correctly via `MPRemoteCommandCenter` and is not affected.

## Related issues

Related to #2564, #2100, #2254, #592.