### PR TITLE
fix(android): normalize legacy ICY punctuation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,4 +62,5 @@ dependencies {
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
     implementation "androidx.lifecycle:lifecycle-process:2.5.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3"
+    testImplementation "junit:junit:4.13.2"
 }

--- a/android/src/main/java/com/doublesymmetry/trackplayer/model/PlaybackMetadata.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/model/PlaybackMetadata.kt
@@ -87,14 +87,14 @@ data class PlaybackMetadata(
                     is IcyInfo -> {
                         val artist: String?
                         val title: String?
-                        val index =
-                            if (entry.title == null) -1 else entry.title!!.indexOf(" - ")
+                        val normalizedTitle = entry.title?.normalizeLegacyIcyPunctuation()
+                        val index = normalizedTitle?.indexOf(" - ") ?: -1
                         if (index != -1) {
-                            artist = entry.title!!.substring(0, index)
-                            title = entry.title!!.substring(index + 3)
+                            artist = normalizedTitle!!.substring(0, index)
+                            title = normalizedTitle.substring(index + 3)
                         } else {
                             artist = null
-                            title = entry.title
+                            title = normalizedTitle
                         }
 
                         return PlaybackMetadata("icy", title = title, url = entry.url, artist = artist)
@@ -198,3 +198,40 @@ data class PlaybackMetadata(
         }
     }
 }
+
+/**
+ * ExoPlayer exposes non-UTF-8 ICY metadata as ISO-8859-1. Some streams use
+ * Windows-1252 punctuation in the C1 range, so map only its defined characters.
+ */
+internal fun String.normalizeLegacyIcyPunctuation(): String = map { character ->
+    when (character) {
+        '\u0080' -> '€'
+        '\u0082' -> '‚'
+        '\u0083' -> 'ƒ'
+        '\u0084' -> '„'
+        '\u0085' -> '…'
+        '\u0086' -> '†'
+        '\u0087' -> '‡'
+        '\u0088' -> 'ˆ'
+        '\u0089' -> '‰'
+        '\u008A' -> 'Š'
+        '\u008B' -> '‹'
+        '\u008C' -> 'Œ'
+        '\u008E' -> 'Ž'
+        '\u0091' -> '‘'
+        '\u0092' -> '’'
+        '\u0093' -> '“'
+        '\u0094' -> '”'
+        '\u0095' -> '•'
+        '\u0096' -> '–'
+        '\u0097' -> '—'
+        '\u0098' -> '˜'
+        '\u0099' -> '™'
+        '\u009A' -> 'š'
+        '\u009B' -> '›'
+        '\u009C' -> 'œ'
+        '\u009E' -> 'ž'
+        '\u009F' -> 'Ÿ'
+        else -> character
+    }
+}.joinToString("")

--- a/android/src/test/java/com/doublesymmetry/trackplayer/model/PlaybackMetadataTest.kt
+++ b/android/src/test/java/com/doublesymmetry/trackplayer/model/PlaybackMetadataTest.kt
@@ -1,0 +1,64 @@
+package com.doublesymmetry.trackplayer.model
+
+import com.google.android.exoplayer2.metadata.Metadata
+import com.google.android.exoplayer2.metadata.icy.IcyInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaybackMetadataTest {
+    @Test
+    fun fromIcy_normalizesWindows1252PunctuationBeforeSplittingTitle() {
+        val metadata = Metadata(
+            IcyInfo(byteArrayOf(), "Probe\u0092s - Hatchback\u0092s", null)
+        )
+
+        val result = PlaybackMetadata.fromIcy(metadata)
+
+        assertEquals("Probe’s", result?.artist)
+        assertEquals("Hatchback’s", result?.title)
+    }
+
+    @Test
+    fun normalizeLegacyIcyPunctuation_mapsOnlyDefinedWindows1252C1Characters() {
+        val cases = listOf(
+            "\u0080" to "€",
+            "\u0081" to "\u0081",
+            "\u0082" to "‚",
+            "\u0083" to "ƒ",
+            "\u0084" to "„",
+            "\u0085" to "…",
+            "\u0086" to "†",
+            "\u0087" to "‡",
+            "\u0088" to "ˆ",
+            "\u0089" to "‰",
+            "\u008A" to "Š",
+            "\u008B" to "‹",
+            "\u008C" to "Œ",
+            "\u008D" to "\u008D",
+            "\u008E" to "Ž",
+            "\u008F" to "\u008F",
+            "\u0090" to "\u0090",
+            "\u0091" to "‘",
+            "\u0092" to "’",
+            "\u0093" to "“",
+            "\u0094" to "”",
+            "\u0095" to "•",
+            "\u0096" to "–",
+            "\u0097" to "—",
+            "\u0098" to "˜",
+            "\u0099" to "™",
+            "\u009A" to "š",
+            "\u009B" to "›",
+            "\u009C" to "œ",
+            "\u009D" to "\u009D",
+            "\u009E" to "ž",
+            "\u009F" to "Ÿ",
+            "Déjà vu" to "Déjà vu",
+            "Already correct ’" to "Already correct ’"
+        )
+
+        cases.forEach { (input, expected) ->
+            assertEquals("input U+${input.first().code.toString(16)}", expected, input.normalizeLegacyIcyPunctuation())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- normalize defined Windows-1252 punctuation exposed as C1 control characters in Android ICY metadata
- normalize before splitting the conventional artist - title value
- preserve undefined C1 controls, already-correct Unicode, ISO-8859-1 accents, null titles, and existing metadata behavior

## Context

ExoPlayer's ICY decoder falls back to ISO-8859-1 when metadata is not valid UTF-8. Some real-world ICY streams send Windows-1252 punctuation, so bytes such as 0x92 reach React Native Track Player as U+0092 instead of the intended U+2019 apostrophe.

## Testing

- PlaybackMetadataTest: 2 tests passed
- upstream v4 example Android assembleDebug: 190 tasks passed

The regression tests exercise real ExoPlayer Metadata and IcyInfo objects, cover every defined Windows-1252 C1 mapping, and verify normalization occurs before artist/title splitting.
